### PR TITLE
Update binary integer description format

### DIFF
--- a/Sources/CoreKit/Models/TextInt+Format.swift
+++ b/Sources/CoreKit/Models/TextInt+Format.swift
@@ -17,59 +17,31 @@ extension TextInt {
     // MARK: Utilities
     //=------------------------------------------------------------------------=
     
-    @inlinable package static func decompose<UTF8>(
-        _ description: UTF8
-    )   -> (sign: Sign, mask: Bit, body: UTF8.SubSequence) where UTF8: Collection<UInt8> {
-        var body = description[...]
-        let sign = self.remove(from: &body, prefix: Self.decode) ?? Sign.plus
-        let mask = self.remove(from: &body, prefix: Self.decode) ?? Bit .zero
-        return (sign: sign, mask: mask, body: body)
+    @inlinable package static func sign(_ text: UInt8) -> Sign? {
+        switch text {
+        case UInt8(ascii: "+"): Sign.plus
+        case UInt8(ascii: "-"): Sign.minus
+        default: nil
+        }
+    }
+    
+    @inlinable package static func mask(_ text: UInt8) -> Void? {
+        switch text {
+        case UInt8(ascii: "&"): Void()
+        default: nil
+        }
     }
     
     @inlinable package static func remove<UTF8, Component>(
-        from description: inout UTF8, 
+        from description: inout UTF8,
         prefix match: (UInt8) -> Component?
-    )   ->  Component? where UTF8: Collection<UInt8>, UTF8 == UTF8.SubSequence {
+    )   -> Component? where UTF8: Collection<UInt8>, UTF8 == UTF8.SubSequence {
         
-        if  let first = description.first {
-            if  let component = match(first) {
-                description.removeFirst()
-                return component
-            }
+        if  let first = description.first, let component = match(first) {
+            description.removeFirst()
+            return component as Component
+        }   else {
+            return nil
         }
-        
-        return nil
-    }
-    
-    //=------------------------------------------------------------------------=
-    // MARK: Utilities x Sign
-    //=------------------------------------------------------------------------=
-    
-    @inlinable package static func decode(_ text: UInt8) -> Sign? {
-        switch text {
-        case UInt8(ascii: "+"): .plus
-        case UInt8(ascii: "-"): .minus
-        default: nil
-        }
-    }
-    
-    @inlinable package static func encode(_ data: Sign) -> UInt8 {
-        UInt8(ascii: data == .plus ? "+" : "-")
-    }
-    
-    //=------------------------------------------------------------------------=
-    // MARK: Utilities x Mask
-    //=------------------------------------------------------------------------=
-    
-    @inlinable package static func decode(_ text: UInt8) -> Bit? {
-        switch text {
-        case UInt8(ascii: "#"): .zero
-        case UInt8(ascii: "&"): .one
-        default: nil
-        }
-    }
-    
-    @inlinable package static func encode(_ data: Bit)  -> UInt8 {
-        UInt8(ascii: data == .zero ? "#" : "&")
     }
 }

--- a/Sources/CoreKit/Models/TextInt.swift
+++ b/Sources/CoreKit/Models/TextInt.swift
@@ -20,15 +20,15 @@
 /// numerals. In other words, it matches the following regular expression:
 ///
 /// ```swift
-/// let regex: Regex = #/^(\+|-)?(#|&)?([0-9A-Za-z]+)$/#
+/// let regex: Regex = #/^(\+|-)?(&)?([0-9A-Za-z]+)$/#
 /// ```
 ///
-/// Negative values must contain a minus sign (`-`) and infinite values must
-/// contain a toggle mask (`&`). Natural values may contain a plus sign (`+`)
-/// and/or a neutral mask (`#`). Zero may alternatively contain a minus sign.
-/// Redundant zeros are also allowed.
+/// Negative values must contain a minus sign (`"-"`) and infinite values must
+/// contain a binary integer infinity mask (`"&"`). Natural values may contain
+/// a plus sign (`"+"`). Zero may contain either sign, or no sign. The numeral
+/// part may also contain redundant leading zeros.
 ///
-/// - Note: The default encoding strategy omits redundant elements.
+/// - Note: The default encoding strategy only includes essential elements.
 ///
 /// - Note: The numerals of infinite values represent some distance from the
 ///   maximum infinite magnitude of an unsigned and arbitrary binary integer.

--- a/Tests/Benchmarks/TextInt+Base10.swift
+++ b/Tests/Benchmarks/TextInt+Base10.swift
@@ -41,7 +41,7 @@ final class TextIntBenchmarksOnRadix10: XCTestCase {
     func testDecodingOneMillionTimesBinaryIntegerAsUX() throws {
         let encoded = blackHoleIdentity(Self.formatter.encode(UX.max))
         
-        for _ in 0 as UX ..< 1_000_000 {
+        for _ in 0 as UX ..< blackHoleIdentity(1_000_000) {
             precondition((try? Self.formatter.decode(encoded) as UX) != nil)
         }
     }
@@ -49,7 +49,7 @@ final class TextIntBenchmarksOnRadix10: XCTestCase {
     func testDecodingOneMillionTimesBinaryIntegerAsUXL() throws {
         let encoded = blackHoleIdentity(Self.formatter.encode(UX.max))
         
-        for _ in 0 as UX ..< 1_000_000 {
+        for _ in 0 as UX ..< blackHoleIdentity(1_000_000) {
             precondition((try? Self.formatter.decode(encoded) as UXL) != nil)
         }
     }
@@ -61,42 +61,42 @@ final class TextIntBenchmarksOnRadix10: XCTestCase {
     func testEncodingFirstOneMillionBinaryIntegerAsUX() throws {
         var counter = UX.zero
         
-        for value in 0 as UX ..< 1_000_000 {
+        for value in 0 as UX ..< blackHoleIdentity(1_000_000) {
             counter += UX(Bit(!Self.formatter.encode(value).isEmpty))
         }
         
-        XCTAssertEqual(counter, 1_000_000)
+        XCTAssertEqual(counter,  blackHoleIdentity(1_000_000))
     }
     
     func testEncodingFirstOneMillionBinaryIntegerAsUXL() throws {
-        var counter = UX.zero, value = UXL(0), increment = UXL(1)
+        var counter = UX.zero, value = UXL.zero, one = UXL.lsb
         
-        for _ in 0 as UX ..< 1_000_000 {
-            value  &+= increment
+        for _ in 0 as UX ..< blackHoleIdentity(1_000_000) {
+            value  &+= one
             counter += UX(Bit(!Self.formatter.encode(value).isEmpty))
         }
         
-        XCTAssertEqual(counter, 1_000_000)
+        XCTAssertEqual(counter,  blackHoleIdentity(1_000_000))
     }
     
     func testEncodingFirstOneMillionSignMagnitudeAsUX() throws {
         var counter = UX.zero
         
-        for value in 0 as UX ..< 1_000_000 {
+        for value in 0 as UX ..< blackHoleIdentity(1_000_000) {
             counter += UX(Bit(!Self.formatter.encode(sign: .plus, magnitude: value).isEmpty))
         }
         
-        XCTAssertEqual(counter, 1_000_000)
+        XCTAssertEqual(counter,  blackHoleIdentity(1_000_000))
     }
     
     func testEncodingFirstOneMillionSignMagnitudeAsUXL() throws {
-        var counter = UX.zero, value = UXL(0), increment = UXL(1)
+        var counter = UX.zero, value = UXL.zero, increment = UXL.lsb
         
-        for _ in 0 as UX ..< 1_000_000 {
+        for _ in 0 as UX ..< blackHoleIdentity(1_000_000) {
             value  &+= increment
             counter += UX(Bit(!Self.formatter.encode(sign: .plus, magnitude: value).isEmpty))
         }
         
-        XCTAssertEqual(counter, 1_000_000)
+        XCTAssertEqual(counter,  blackHoleIdentity(1_000_000))
     }
 }

--- a/Tests/Benchmarks/TextInt+Base16.swift
+++ b/Tests/Benchmarks/TextInt+Base16.swift
@@ -41,7 +41,7 @@ final class TextIntBenchmarksOnRadix16: XCTestCase {
     func testDecodingOneMillionTimesBinaryIntegerAsUX() throws {
         let encoded = blackHoleIdentity(Self.formatter.encode(UX.max))
         
-        for _ in 0 as UX ..<  1_000_000 {
+        for _ in 0 as UX ..< blackHoleIdentity(1_000_000) {
             precondition((try? Self.formatter.decode(encoded) as UX) != nil)
         }
     }
@@ -49,7 +49,7 @@ final class TextIntBenchmarksOnRadix16: XCTestCase {
     func testDecodingOneMillionTimesBinaryIntegerAsUXL() throws {
         let encoded = blackHoleIdentity(Self.formatter.encode(UX.max))
         
-        for _ in 0 as UX ..<  1_000_000 {
+        for _ in 0 as UX ..< blackHoleIdentity(1_000_000) {
             precondition((try? Self.formatter.decode(encoded) as UXL) != nil)
         }
     }
@@ -61,42 +61,42 @@ final class TextIntBenchmarksOnRadix16: XCTestCase {
     func testEncodingFirstOneMillionBinaryIntegerAsUX() throws {
         var counter = UX.zero
         
-        for value in 0 as UX ..< 1_000_000 {
+        for value in 0 as UX ..< blackHoleIdentity(1_000_000) {
             counter += UX(Bit(!Self.formatter.encode(value).isEmpty))
         }
         
-        XCTAssertEqual(counter, 1_000_000)
+        XCTAssertEqual(counter,  blackHoleIdentity(1_000_000))
     }
     
     func testEncodingFirstOneMillionBinaryIntegerAsUXL() throws {
-        var counter = UX.zero, value = UXL(0), increment = UXL(1)
-        
-        for _ in 0 as UX ..< 1_000_000 {
-            value  &+= increment
+        var counter = UX.zero, value = UXL.zero, one = UXL.lsb
+
+        for _ in 0 as UX ..< blackHoleIdentity(1_000_000) {
+            value  &+= one
             counter += UX(Bit(!Self.formatter.encode(value).isEmpty))
         }
         
-        XCTAssertEqual(counter, 1_000_000)
+        XCTAssertEqual(counter,  blackHoleIdentity(1_000_000))
     }
     
     func testEncodingFirstOneMillionSignMagnitudeAsUX() throws {
         var counter = UX.zero
         
-        for value in 0 as UX ..< 1_000_000 {
+        for value in 0 as UX ..< blackHoleIdentity(1_000_000) {
             counter += UX(Bit(!Self.formatter.encode(sign: .plus, magnitude: value).isEmpty))
         }
         
-        XCTAssertEqual(counter, 1_000_000)
+        XCTAssertEqual(counter,  blackHoleIdentity(1_000_000))
     }
     
     func testEncodingFirstOneMillionSignMagnitudeAsUXL() throws {
-        var counter = UX.zero, value = UXL(0), increment = UXL(1)
+        var counter = UX.zero, value = UXL.zero, one = UXL.lsb
         
-        for _ in 0 as UX ..< 1_000_000 {
-            value  &+= increment
+        for _ in 0 as UX ..< blackHoleIdentity(1_000_000) {
+            value  &+= one
             counter += UX(Bit(!Self.formatter.encode(sign: .plus, magnitude: value).isEmpty))
         }
         
-        XCTAssertEqual(counter, 1_000_000)
+        XCTAssertEqual(counter,  blackHoleIdentity(1_000_000))
     }
 }


### PR DESCRIPTION
- #132

This patch addresses the above issue by removing the neutral mask (`"#"`) from the current binary integer description format. It also updates internal methods to ease support of future formats. In particular, I may want to encode and decode radix indicator prefixes (`"0x"`) at some point. The internal algorithms now accept an arbitrary prefix sequence.