### PR TITLE
RandomIntIop interoperability module

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Ultimathnum-Development.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Ultimathnum-Development.xcscheme
@@ -98,6 +98,20 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Ultimathiop"
+               BuildableName = "Ultimathiop"
+               BlueprintName = "Ultimathiop"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "CoreIop"
                BuildableName = "CoreIop"
                BlueprintName = "CoreIop"
@@ -112,9 +126,37 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DoubleIntIop"
+               BuildableName = "DoubleIntIop"
+               BlueprintName = "DoubleIntIop"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "InfiniIntIop"
                BuildableName = "InfiniIntIop"
                BlueprintName = "InfiniIntIop"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "RandomIntIop"
+               BuildableName = "RandomIntIop"
+               BlueprintName = "RandomIntIop"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Ultimathnum.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Ultimathnum.xcscheme
@@ -70,6 +70,48 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DoubleIntIop"
+               BuildableName = "DoubleIntIop"
+               BlueprintName = "DoubleIntIop"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "RandomIntIop"
+               BuildableName = "RandomIntIop"
+               BlueprintName = "RandomIntIop"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Ultimathiop"
+               BuildableName = "Ultimathiop"
+               BlueprintName = "Ultimathiop"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "InfiniIntKit"
                BuildableName = "InfiniIntKit"
                BlueprintName = "InfiniIntKit"

--- a/.swiftpm/xcode/xcshareddata/xctestplans/Ultimathnum-Development.xctestplan
+++ b/.swiftpm/xcode/xcshareddata/xctestplans/Ultimathnum-Development.xctestplan
@@ -54,14 +54,6 @@
       "parallelizable" : true,
       "target" : {
         "containerPath" : "container:",
-        "identifier" : "CoreIopTests",
-        "name" : "CoreIopTests"
-      }
-    },
-    {
-      "parallelizable" : true,
-      "target" : {
-        "containerPath" : "container:",
         "identifier" : "CoreKitTests",
         "name" : "CoreKitTests"
       }
@@ -70,40 +62,8 @@
       "parallelizable" : true,
       "target" : {
         "containerPath" : "container:",
-        "identifier" : "DoubleIntIopTests",
-        "name" : "DoubleIntIopTests"
-      }
-    },
-    {
-      "parallelizable" : true,
-      "target" : {
-        "containerPath" : "container:",
-        "identifier" : "DoubleIntKitTests",
-        "name" : "DoubleIntKitTests"
-      }
-    },
-    {
-      "parallelizable" : true,
-      "target" : {
-        "containerPath" : "container:",
-        "identifier" : "FibonacciKitTests",
-        "name" : "FibonacciKitTests"
-      }
-    },
-    {
-      "parallelizable" : true,
-      "target" : {
-        "containerPath" : "container:",
-        "identifier" : "InfiniIntIopTests",
-        "name" : "InfiniIntIopTests"
-      }
-    },
-    {
-      "parallelizable" : true,
-      "target" : {
-        "containerPath" : "container:",
-        "identifier" : "InfiniIntKitTests",
-        "name" : "InfiniIntKitTests"
+        "identifier" : "CoreIopTests",
+        "name" : "CoreIopTests"
       }
     },
     {
@@ -118,8 +78,32 @@
       "parallelizable" : true,
       "target" : {
         "containerPath" : "container:",
-        "identifier" : "UltimathiopTests",
-        "name" : "UltimathiopTests"
+        "identifier" : "RandomIntIopTests",
+        "name" : "RandomIntIopTests"
+      }
+    },
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "DoubleIntIopTests",
+        "name" : "DoubleIntIopTests"
+      }
+    },
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "InfiniIntKitTests",
+        "name" : "InfiniIntKitTests"
+      }
+    },
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "FibonacciKitTests",
+        "name" : "FibonacciKitTests"
       }
     },
     {
@@ -128,6 +112,30 @@
         "containerPath" : "container:",
         "identifier" : "UltimathnumTests",
         "name" : "UltimathnumTests"
+      }
+    },
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "UltimathiopTests",
+        "name" : "UltimathiopTests"
+      }
+    },
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "InfiniIntIopTests",
+        "name" : "InfiniIntIopTests"
+      }
+    },
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "DoubleIntKitTests",
+        "name" : "DoubleIntKitTests"
       }
     }
   ],

--- a/.swiftpm/xcode/xcshareddata/xctestplans/Ultimathnum.xctestplan
+++ b/.swiftpm/xcode/xcshareddata/xctestplans/Ultimathnum.xctestplan
@@ -16,16 +16,24 @@
       "parallelizable" : true,
       "target" : {
         "containerPath" : "container:",
-        "identifier" : "CoreIopTests",
-        "name" : "CoreIopTests"
+        "identifier" : "RandomIntKitTests",
+        "name" : "RandomIntKitTests"
       }
     },
     {
       "parallelizable" : true,
       "target" : {
         "containerPath" : "container:",
-        "identifier" : "CoreKitTests",
-        "name" : "CoreKitTests"
+        "identifier" : "UltimathnumTests",
+        "name" : "UltimathnumTests"
+      }
+    },
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "RandomIntIopTests",
+        "name" : "RandomIntIopTests"
       }
     },
     {
@@ -40,8 +48,40 @@
       "parallelizable" : true,
       "target" : {
         "containerPath" : "container:",
+        "identifier" : "InfiniIntKitTests",
+        "name" : "InfiniIntKitTests"
+      }
+    },
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:",
         "identifier" : "DoubleIntKitTests",
         "name" : "DoubleIntKitTests"
+      }
+    },
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "UltimathiopTests",
+        "name" : "UltimathiopTests"
+      }
+    },
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "CoreKitTests",
+        "name" : "CoreKitTests"
+      }
+    },
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "CoreIopTests",
+        "name" : "CoreIopTests"
       }
     },
     {
@@ -58,38 +98,6 @@
         "containerPath" : "container:",
         "identifier" : "InfiniIntIopTests",
         "name" : "InfiniIntIopTests"
-      }
-    },
-    {
-      "parallelizable" : true,
-      "target" : {
-        "containerPath" : "container:",
-        "identifier" : "InfiniIntKitTests",
-        "name" : "InfiniIntKitTests"
-      }
-    },
-    {
-      "parallelizable" : true,
-      "target" : {
-        "containerPath" : "container:",
-        "identifier" : "RandomIntKitTests",
-        "name" : "RandomIntKitTests"
-      }
-    },
-    {
-      "parallelizable" : true,
-      "target" : {
-        "containerPath" : "container:",
-        "identifier" : "UltimathiopTests",
-        "name" : "UltimathiopTests"
-      }
-    },
-    {
-      "parallelizable" : true,
-      "target" : {
-        "containerPath" : "container:",
-        "identifier" : "UltimathnumTests",
-        "name" : "UltimathnumTests"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -53,6 +53,10 @@ let package = Package(
             targets: ["InfiniIntKit"]
         ),
         .library(
+            name: "RandomIntIop",
+            targets: ["RandomIntIop"]
+        ),
+        .library(
             name: "RandomIntKit",
             targets: ["RandomIntKit"]
         ),
@@ -135,6 +139,14 @@ let package = Package(
             dependencies: ["PrototypeKit", "TestKit"]
         ),
         .target(
+            name: "RandomIntIop",
+            dependencies: ["CoreIop", "RandomIntKit"]
+        ),
+        .testTarget(
+            name: "RandomIntIopTests",
+            dependencies: ["RandomIntIop", "TestKit"]
+        ),
+        .target(
             name: "RandomIntKit",
             dependencies: ["CoreKit"]
         ),
@@ -144,15 +156,15 @@ let package = Package(
         ),
         .target(
             name: "TestKit",
-            dependencies: ["CoreKit", "RandomIntKit"]
+            dependencies: ["CoreKit", "RandomIntIop"]
         ),
         .target(
             name: "Ultimathiop",
-            dependencies: ["CoreIop", "DoubleIntIop", "FibonacciKit", "InfiniIntIop", "RandomIntKit"]
+            dependencies: ["CoreIop", "DoubleIntIop", "FibonacciKit", "InfiniIntIop", "RandomIntIop"]
         ),
         .testTarget(
             name: "UltimathiopTests",
-            dependencies: ["Ultimathiop", "TestKit"]
+            dependencies: ["TestKit", "Ultimathiop"]
         ),
         .target(
             name: "Ultimathnum",
@@ -160,7 +172,7 @@ let package = Package(
         ),
         .testTarget(
             name: "UltimathnumTests",
-            dependencies: ["Ultimathnum", "TestKit"]
+            dependencies: ["TestKit", "Ultimathnum"]
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Choose target dependencies from this list of products.
 .product(name: "CoreIop",      package: "Ultimathnum"),
 .product(name: "DoubleIntIop", package: "Ultimathnum"),
 .product(name: "InfiniIntIop", package: "Ultimathnum"),
+.product(name: "RandomIntIop", package: "Ultimathnum"),
 ```
 
 <a name="installation-how-to-run-unit-tests"/>

--- a/Sources/CoreIop/Randomness.swift
+++ b/Sources/CoreIop/Randomness.swift
@@ -8,22 +8,10 @@
 //=----------------------------------------------------------------------------=
 
 import CoreKit
-import RandomIntKit
-import TestKit
 
 //*============================================================================*
-// MARK: * Fuzzer Int x Stdlib
+// MARK: * Randomness
 //*============================================================================*
 
-@Suite struct FuzzerIntTestsOnStdlib {
-    
-    //=------------------------------------------------------------------------=
-    // MARK: Tests
-    //=------------------------------------------------------------------------=
-    
-    @Test func metadata() {
-        #expect(FuzzerInt.Stdlib.self as Any is any Swift.RandomNumberGenerator.Type)
-        #expect(MemoryLayout<FuzzerInt.Stdlib>.size == 8)
-    }
-}
-
+/// An interoperable source of uniformly distributed random data.
+public protocol RandomnessInteroperable: Interoperable, Randomness where Stdlib: Swift.RandomNumberGenerator { }

--- a/Sources/RandomIntIop/FuzzerInt.swift
+++ b/Sources/RandomIntIop/FuzzerInt.swift
@@ -1,0 +1,60 @@
+//=----------------------------------------------------------------------------=
+// This source file is part of the Ultimathnum open source project.
+//
+// Copyright (c)  2023 Oscar Byström Ericsson
+// Licensed under Apache License, Version 2.0
+//
+// See http://www.apache.org/licenses/LICENSE-2.0 for license information.
+//=----------------------------------------------------------------------------=
+
+import CoreIop
+import CoreKit
+import RandomIntKit
+
+//*============================================================================*
+// MARK: * Fuzzer Int x Stdlib
+//*============================================================================*
+
+extension FuzzerInt: RandomnessInteroperable {
+    
+    //=------------------------------------------------------------------------=
+    // MARK: Initializers
+    //=------------------------------------------------------------------------=
+    
+    @inlinable public init(_ source: consuming Stdlib) {
+        self = source.base
+    }
+    
+    @inlinable public consuming func stdlib() -> Stdlib {
+        Stdlib(self)
+    }
+    
+    //*========================================================================*
+    // MARK: * Stdlib
+    //*========================================================================*
+    
+    @frozen public struct Stdlib: Equatable, RandomNumberGenerator, Sendable {
+        
+        //=--------------------------------------------------------------------=
+        // MARK: State
+        //=--------------------------------------------------------------------=
+        
+        @usableFromInline var base: FuzzerInt
+        
+        //=--------------------------------------------------------------------=
+        // MARK: Initializers
+        //=--------------------------------------------------------------------=
+        
+        @inlinable init(_ base: consuming FuzzerInt) {
+            self.base = base
+        }
+        
+        //=--------------------------------------------------------------------=
+        // MARK: Utilities
+        //=--------------------------------------------------------------------=
+        
+        @inlinable public mutating func next() -> Swift.UInt64 {
+            Swift.UInt64(self.base.next(as: U64.self))
+        }
+    }
+}

--- a/Sources/RandomIntIop/RandomInt.swift
+++ b/Sources/RandomIntIop/RandomInt.swift
@@ -7,16 +7,12 @@
 // See http://www.apache.org/licenses/LICENSE-2.0 for license information.
 //=----------------------------------------------------------------------------=
 
+import CoreIop
+import CoreKit
+import RandomIntKit
+
 //*============================================================================*
-// MARK: * Exports
+// MARK: * Random Int x Stdlib
 //*============================================================================*
 
-@_exported import CoreIop
-@_exported import CoreKit
-@_exported import DoubleIntIop
-@_exported import DoubleIntKit
-@_exported import FibonacciKit
-@_exported import InfiniIntIop
-@_exported import InfiniIntKit
-@_exported import RandomIntIop
-@_exported import RandomIntKit
+extension RandomInt: RandomnessInteroperable { }

--- a/Sources/RandomIntKit/FuzzerInt.swift
+++ b/Sources/RandomIntKit/FuzzerInt.swift
@@ -21,7 +21,7 @@ import CoreKit
 ///
 /// - Important: It may use a different algorithm in the future.
 ///
-@frozen public struct FuzzerInt: Equatable, Interoperable, Randomness, Sendable {
+@frozen public struct FuzzerInt: Equatable, Randomness, Sendable {
     
     //=------------------------------------------------------------------------=
     // MARK: State
@@ -35,14 +35,6 @@ import CoreKit
     
     @inlinable public init(seed: U64) {
         self.state = (seed)
-    }
-    
-    @inlinable public init(_ source: consuming Stdlib) {
-        self = source.base
-    }
-    
-    @inlinable public consuming func stdlib() -> Stdlib {
-        Stdlib(self)
     }
     
     //=------------------------------------------------------------------------=
@@ -59,34 +51,5 @@ import CoreKit
         next = (next ^ (next &>> 30)) &* 0xbf58476d1ce4e5b9
         next = (next ^ (next &>> 27)) &* 0x94d049bb133111eb
         return (next ^ (next &>> 31))
-    }
-    
-    //*========================================================================*
-    // MARK: * Stdlib
-    //*========================================================================*
-    
-    @frozen public struct Stdlib: Equatable, RandomNumberGenerator, Sendable {
-        
-        //=--------------------------------------------------------------------=
-        // MARK: State
-        //=--------------------------------------------------------------------=
-        
-        @usableFromInline var base: FuzzerInt
-        
-        //=--------------------------------------------------------------------=
-        // MARK: Initializers
-        //=--------------------------------------------------------------------=
-        
-        @inlinable init(_ base: consuming FuzzerInt) {
-            self.base = base
-        }
-        
-        //=--------------------------------------------------------------------=
-        // MARK: Utilities
-        //=--------------------------------------------------------------------=
-        
-        @inlinable public mutating func next() -> Swift.UInt64 {
-            Swift.UInt64(self.base.next(as: U64.self))
-        }
     }
 }

--- a/Tests/CoreKitTests/DataInteger+Addition.swift
+++ b/Tests/CoreKitTests/DataInteger+Addition.swift
@@ -8,6 +8,7 @@
 //=----------------------------------------------------------------------------=
 
 import CoreKit
+import RandomIntIop
 import RandomIntKit
 import TestKit
 

--- a/Tests/RandomIntIopTests/FuzerInt.swift
+++ b/Tests/RandomIntIopTests/FuzerInt.swift
@@ -1,0 +1,61 @@
+//=----------------------------------------------------------------------------=
+// This source file is part of the Ultimathnum open source project.
+//
+// Copyright (c)  2023 Oscar Byström Ericsson
+// Licensed under Apache License, Version 2.0
+//
+// See http://www.apache.org/licenses/LICENSE-2.0 for license information.
+//=----------------------------------------------------------------------------=
+
+import CoreIop
+import CoreKit
+import RandomIntIop
+import RandomIntKit
+import TestKit
+
+//*============================================================================*
+// MARK: * Fuzzer Int x Stdlib
+//*============================================================================*
+
+@Suite struct FuzzerIntStdlibTests {
+    
+    //=------------------------------------------------------------------------=
+    // MARK: Tests
+    //=------------------------------------------------------------------------=
+    
+    @Test(
+        "FuzzerInt.Stdlib: metadata",
+        Tag.List.tags(.documentation)
+    )   func metadata() {
+        #expect(MemoryLayout<FuzzerInt.Stdlib>.size == 8)
+        #expect(FuzzerInt.Stdlib.self as Any is any Swift.RandomNumberGenerator.Type)
+    }
+    
+    
+    @Test(
+        "FuzzerInt.Stdlib: prefix",
+        Tag.List.tags(.documentation),
+        arguments: fuzzers
+    )   func prefix(randomness: consuming FuzzerInt) throws {
+        for _ in 0 ..< 8 {
+            var normal  = FuzzerInt(seed: randomness.next())
+            var (copy)  = normal
+            var stdlibX = normal.stdlib
+            var stdlibY = normal.stdlib()
+            
+            for _ in 0 ..< 8 {
+                #expect(copy == normal)
+                #expect(stdlibX == stdlibY)
+                
+                let element: FuzzerInt.Element = normal.next()
+                                
+                #expect(copy.stdlib.next() == Swift.UInt64(element), "stdlib modify")
+                #expect(((stdlibX)).next() == Swift.UInt64(element), "stdlib read")
+                #expect(((stdlibY)).next() == Swift.UInt64(element), "stdlib consuming")
+                
+                #expect(copy == normal)
+                #expect(stdlibX == stdlibY)
+            }
+        }
+    }
+}

--- a/Tests/RandomIntIopTests/RandomInt.swift
+++ b/Tests/RandomIntIopTests/RandomInt.swift
@@ -7,7 +7,9 @@
 // See http://www.apache.org/licenses/LICENSE-2.0 for license information.
 //=----------------------------------------------------------------------------=
 
+import CoreIop
 import CoreKit
+import RandomIntIop
 import RandomIntKit
 import TestKit
 
@@ -15,22 +17,32 @@ import TestKit
 // MARK: * Random Int x Stdlib
 //*============================================================================*
 
-@Suite struct RandomIntTestsOnStdlib {
+@Suite struct RandomIntStdlibTests {
     
     //=------------------------------------------------------------------------=
     // MARK: Tests
     //=------------------------------------------------------------------------=
     
-    @Test func metadata() {
-        #expect(RandomInt.Stdlib.self as Any is any Swift.RandomNumberGenerator.Type)
+    @Test(
+        "RandomInt.Stdlib: metadata",
+        Tag.List.tags(.documentation)
+    )   func metadata() {
         #expect(MemoryLayout<RandomInt.Stdlib>.size == 0)
+        #expect(RandomInt.Stdlib.self as Any is any Swift.RandomNumberGenerator.Type)
     }
     
-    @Test func stdlib() {
-        let custom = RandomInt(Swift.SystemRandomNumberGenerator())
-        let stdlib: Swift.SystemRandomNumberGenerator = custom.stdlib()
-        #expect(MemoryLayout.size(ofValue: custom) == Swift.Int.zero)
-        #expect(MemoryLayout.size(ofValue: stdlib) == Swift.Int.zero)
+    @Test(
+        "RandomInt.Stdlib: prefix",
+        Tag.List.tags(.documentation),
+        TimeLimitTrait.timeLimit(.minutes(1)),
+        arguments: CollectionOfOne(32)
+    )   func prefix(count: Swift.Int) {
+        
+        var stdlib = RandomInt().stdlib()
+        var uniques: Set<Swift.UInt64> = []
+        
+        while uniques.count < count {
+            uniques.insert(stdlib.next())
+        }
     }
 }
-

--- a/Tests/RandomIntKitTests/FuzzerInt.swift
+++ b/Tests/RandomIntKitTests/FuzzerInt.swift
@@ -21,9 +21,13 @@ import TestKit
     // MARK: Tests
     //=------------------------------------------------------------------------=
     
-    @Test func metadata() {
-        #expect(FuzzerInt.self as Any is any Randomness.Type)
+    @Test(
+        "FuzzerInt: metadata",
+        Tag.List.tags(.documentation)
+    )   func metadata() {
         #expect(MemoryLayout<FuzzerInt>.size == 8)
+        #expect(MemoryLayout<FuzzerInt.Element>.size == 8)
+        #expect(FuzzerInt.self as Any is any Randomness.Type)
     }
     
     @Test(
@@ -36,23 +40,13 @@ import TestKit
         (~1 as I64, [0xf3203e9039f4a821, 0xba56949915dcf9e9, 0xd0d5127a96e8d90d, 0x1ef156bb76650c37] as [U64]),
         (~0 as I64, [0xe4d971771b652c20, 0xe99ff867dbf682c9, 0x382ff84cb27281e9, 0x6d1db36ccba982d2] as [U64]),
         
-    ])) func prefix(seed: I64, expectation: [U64]) {
+    ])) func prefix(
+        seed: I64, expectation: [U64]
+    )   throws {
+        
         var randomness = FuzzerInt(seed: U64(raw: seed))
         for element in expectation {
-            var copy    = randomness
-            var stdlibX = randomness.stdlib
-            var stdlibY = randomness.stdlib()
-            
-            #expect(randomness == copy)
-            #expect(stdlibX == stdlibY)
-            
-            #expect(randomness .next() ==             (element), "normal")
-            #expect(copy.stdlib.next() == Swift.UInt64(element), "stdlib modify")
-            #expect(((stdlibX)).next() == Swift.UInt64(element), "stdlib read")
-            #expect(((stdlibY)).next() == Swift.UInt64(element), "stdlib consuming")
-            
-            #expect(randomness == copy)
-            #expect(stdlibX == stdlibY)
+            try #require(randomness.next() == element)
         }
     }
 }

--- a/Tests/RandomIntKitTests/RandomInt.swift
+++ b/Tests/RandomIntKitTests/RandomInt.swift
@@ -21,8 +21,27 @@ import TestKit
     // MARK: Tests
     //=------------------------------------------------------------------------=
     
-    @Test func metadata() {
-        #expect(RandomInt.self as Any is any Randomness.Type)
+    @Test(
+        "RandomInt: metadata",
+        Tag.List.tags(.documentation)
+    )   func metadata() {
         #expect(MemoryLayout<RandomInt>.size == 0)
+        #expect(MemoryLayout<RandomInt.Element>.size == 8)
+        #expect(RandomInt.self as Any is any Randomness.Type)
+    }
+    
+    @Test(
+        "RandomInt: prefix",
+        Tag.List.tags(.documentation),
+        TimeLimitTrait.timeLimit(.minutes(1)),
+        arguments: CollectionOfOne(32)
+    )   func prefix(count: Swift.Int) {
+        
+        var stdlib = RandomInt()
+        var uniques: Set<U64> = []
+        
+        while uniques.count < 32 {
+            uniques.insert(stdlib.next())
+        }
     }
 }

--- a/Tests/UltimathiopTests/BinaryInteger+Text.swift
+++ b/Tests/UltimathiopTests/BinaryInteger+Text.swift
@@ -10,6 +10,7 @@
 import CoreIop
 import CoreKit
 import InfiniIntKit
+import RandomIntIop
 import RandomIntKit
 import TestKit
 

--- a/Tests/UltimathnumTests/BinaryInteger+Factorization.swift
+++ b/Tests/UltimathnumTests/BinaryInteger+Factorization.swift
@@ -8,8 +8,9 @@
 //=----------------------------------------------------------------------------=
 
 import CoreKit
-import RandomIntKit
 import InfiniIntKit
+import RandomIntIop
+import RandomIntKit
 import TestKit
 
 //*============================================================================*


### PR DESCRIPTION
This patch adds the following modules:

- RandomIntIop

The following protocols have been added:

- RandomnessInteroperable

Additionally, the following changes have been made:

- `FuzzerInt.Stdlib` has been moved to `RandomIntIop`
