### PR TITLE
Proper over-allocating shifts

### DIFF
--- a/Sources/CoreKit/BinaryInteger+Shift.swift
+++ b/Sources/CoreKit/BinaryInteger+Shift.swift
@@ -19,9 +19,9 @@ extension BinaryInteger {
     
     /// Performs an ascending smart shift.
     ///
-    /// - Note: The filler bit is either `0` (up) or `appendix` (down).
+    /// ### Binary Integer Shift
     ///
-    /// - Note: A `distance` greater than `IX.max` is a directional flush.
+    /// - Note: The filler bit is either `0` (up) or `appendix` (down).
     ///
     @inlinable public static func <<=(instance: inout Self, distance: some BinaryInteger) {
         instance = instance << distance
@@ -29,44 +29,46 @@ extension BinaryInteger {
     
     /// Performs an ascending smart shift.
     ///
+    /// ### Binary Integer Shift
+    ///
     /// - Note: The filler bit is either `0` (up) or `appendix` (down).
     ///
-    /// - Note: A `distance` greater than `IX.max` is a directional flush.
-    ///
     @inlinable public static func <<(instance: consuming Self, distance: some BinaryInteger) -> Self {
-        //=--------------------------------------=
         if  distance.isInfinite {
             return instance.up(Count.infinity)
         }
         //=--------------------------------------=
-        let max = Self.size.isInfinite ? IX.max : IX(raw: Shift<Magnitude>.max.value)
+        let limit = IX(size: Self.self)?.decremented().unchecked() ?? IX.max
         //=--------------------------------------=
         if  distance.isNegative {
             
-            if  distance >= max.complement() {
+            if  distance >= limit.complement() {
                 return instance.down(Shift(unchecked: Count(Natural(unchecked: IX(load: distance).complement()))))
                 
             }   else {
-                return instance.down(Count.infinity) // flush >= IX.max as per protocol
+                return instance.down(Count.infinity)
             }
             
         }   else {
 
-            if  distance <= UX(raw: max) {
+            if  distance <= UX(raw: limit) {
                 return instance.up(Shift(unchecked: Count(Natural(unchecked: IX(load: distance)))))
                 
+            }   else if !Self.isArbitrary {
+                return instance.up(Count.infinity)
+                
             }   else {
-                return instance.up(Count.infinity) //.. flush >= IX.max as per protocol
+                return instance.veto({ !$0.isZero }).unwrap(String.overallocation())
             }
             
         }
     }
     
     /// Performs a descending smart shift.
+    /// 
+    /// ### Binary Integer Shift
     ///
     /// - Note: The filler bit is either `0` (up) or `appendix` (down).
-    ///
-    /// - Note: A `distance` greater than `IX.max` is a directional flush.
     ///
     @inlinable public static func >>=(instance: inout Self, distance: some BinaryInteger) {
         instance = instance >> distance
@@ -74,34 +76,36 @@ extension BinaryInteger {
     
     /// Performs a descending smart shift.
     ///
+    /// ### Binary Integer Shift
+    ///
     /// - Note: The filler bit is either `0` (up) or `appendix` (down).
     ///
-    /// - Note: A `distance` greater than `IX.max` is a directional flush.
-    ///
     @inlinable public static func >>(instance: consuming Self, distance: some BinaryInteger) -> Self {
-        //=--------------------------------------=
         if  distance.isInfinite {
             return instance.down(Count.infinity)
         }
         //=--------------------------------------=
-        let max = Self.size.isInfinite ? IX.max : IX(raw: Shift<Magnitude>.max.value)
+        let limit = IX(size: Self.self)?.decremented().unchecked() ?? IX.max
         //=--------------------------------------=
         if  distance.isNegative {
             
-            if  distance >= max.complement() {
+            if  distance >= limit.complement() {
                 return instance.up(Shift(unchecked: Count(Natural(unchecked: IX(load: distance).complement()))))
                 
+            }   else if !Self.isArbitrary {
+                return instance.up(Count.infinity)
+                
             }   else {
-                return instance.up(Count.infinity) //.. flush >= IX.max as per protocol
+                return instance.veto({ !$0.isZero }).unwrap(String.overallocation())
             }
             
         }   else {
 
-            if  distance <= UX(raw: max) {
+            if  distance <= UX(raw: limit) {
                 return instance.down(Shift(unchecked: Count(Natural(unchecked: IX(load: distance)))))
                 
             }   else {
-                return instance.down(Count.infinity) // flush >= IX.max as per protocol
+                return instance.down(Count.infinity)
             }
             
         }
@@ -120,9 +124,9 @@ extension BinaryInteger {
     
     /// Performs an ascending smart shift.
     ///
-    /// - Note: The filler bit is either `0` (up) or `appendix` (down).
+    /// ### Binary Integer Shift
     ///
-    /// - Note: The default integer literal is `Swift.Int`.
+    /// - Note: The filler bit is either `0` (up) or `appendix` (down).
     ///
     @inlinable public static func <<=(instance: inout Self, distance: Swift.Int) {
         instance <<= IX(distance)
@@ -130,9 +134,9 @@ extension BinaryInteger {
     
     /// Performs an ascending smart shift.
     ///
-    /// - Note: The filler bit is either `0` (up) or `appendix` (down).
+    /// ### Binary Integer Shift
     ///
-    /// - Note: The default integer literal is `Swift.Int`.
+    /// - Note: The filler bit is either `0` (up) or `appendix` (down).
     ///
     @inlinable public static func <<(instance: consuming Self, distance: Swift.Int) -> Self {
         instance <<  IX(distance)
@@ -140,9 +144,9 @@ extension BinaryInteger {
     
     /// Performs a descending smart shift.
     ///
-    /// - Note: The filler bit is either `0` (up) or `appendix` (down).
+    /// ### Binary Integer Shift
     ///
-    /// - Note: The default integer literal is `Swift.Int`.
+    /// - Note: The filler bit is either `0` (up) or `appendix` (down).
     ///
     @inlinable public static func >>=(instance: inout Self, distance: Swift.Int) {
         instance >>= IX(distance)
@@ -150,9 +154,9 @@ extension BinaryInteger {
     
     /// Performs a descending smart shift.
     ///
-    /// - Note: The filler bit is either `0` (up) or `appendix` (down).
+    /// ### Binary Integer Shift
     ///
-    /// - Note: The default integer literal is `Swift.Int`.
+    /// - Note: The filler bit is either `0` (up) or `appendix` (down).
     ///
     @inlinable public static func >>(instance: consuming Self, distance: Swift.Int) -> Self {
         instance >>  IX(distance)
@@ -171,11 +175,9 @@ extension BinaryInteger {
     
     /// Performs an ascending smart shift.
     ///
+    /// ### Binary Integer Shift
+    ///
     /// - Note: The filler bit is either `0` (up) or `appendix` (down).
-    ///
-    /// - Note: A `distance` greater than `IX.max` is a directional flush.
-    ///
-    /// - Note: This method improves `Count` ergonomics.
     ///
     @inlinable public consuming func up(_ distance: Count) -> Self {
         if  let distance = Shift<Magnitude>(exactly: distance) {
@@ -187,11 +189,9 @@ extension BinaryInteger {
     
     /// Performs a descending smart shift.
     ///
+    /// ### Binary Integer Shift
+    ///
     /// - Note: The filler bit is either `0` (up) or `appendix` (down).
-    ///
-    /// - Note: A `distance` greater than `IX.max` is a directional flush.
-    ///
-    /// - Note: This method improves `Count` ergonomics.
     ///
     @inlinable public consuming func down(_ distance: Count) -> Self {
         if  let distance = Shift<Magnitude>(exactly: distance) {
@@ -214,6 +214,8 @@ extension SystemsInteger {
     
     /// Performs an ascending masked shift.
     ///
+    /// ### Binary Integer Shift
+    ///
     /// - Note: The filler bit is either `0` (up) or `appendix` (down).
     ///
     @inlinable public static func &<<=(instance: inout Self, distance: some BinaryInteger) {
@@ -221,6 +223,8 @@ extension SystemsInteger {
     }
     
     /// Performs an ascending masked shift.
+    ///
+    /// ### Binary Integer Shift
     ///
     /// - Note: The filler bit is either `0` (up) or `appendix` (down).
     ///
@@ -230,6 +234,8 @@ extension SystemsInteger {
     
     /// Performs a descending masked shift.
     ///
+    /// ### Binary Integer Shift
+    ///
     /// - Note: The filler bit is either `0` (up) or `appendix` (down).
     ///
     @inlinable public static func &>>=(instance: inout Self, distance: some BinaryInteger) {
@@ -237,6 +243,8 @@ extension SystemsInteger {
     }
     
     /// Performs a descending masked shift.
+    ///
+    /// ### Binary Integer Shift
     ///
     /// - Note: The filler bit is either `0` (up) or `appendix` (down).
     ///
@@ -257,9 +265,9 @@ extension SystemsInteger {
     
     /// Performs an ascending masked shift.
     ///
-    /// - Note: The filler bit is either `0` (up) or `appendix` (down).
+    /// ### Binary Integer Shift
     ///
-    /// - Note: The default integer literal is `Swift.Int`.
+    /// - Note: The filler bit is either `0` (up) or `appendix` (down).
     ///
     @inlinable public static func &<<=(instance: inout Self, distance: Swift.Int) {
         instance &<<= IX(distance)
@@ -267,9 +275,9 @@ extension SystemsInteger {
     
     /// Performs an ascending masked shift.
     ///
-    /// - Note: The filler bit is either `0` (up) or `appendix` (down).
+    /// ### Binary Integer Shift
     ///
-    /// - Note: The default integer literal is `Swift.Int`.
+    /// - Note: The filler bit is either `0` (up) or `appendix` (down).
     ///
     @inlinable public static func &<<(instance: consuming Self, distance: Swift.Int) -> Self {
         instance &<<  IX(distance)
@@ -277,9 +285,9 @@ extension SystemsInteger {
     
     /// Performs a descending masked shift.
     ///
-    /// - Note: The filler bit is either `0` (up) or `appendix` (down).
+    /// ### Binary Integer Shift
     ///
-    /// - Note: The default integer literal is `Swift.Int`.
+    /// - Note: The filler bit is either `0` (up) or `appendix` (down).
     ///
     @inlinable public static func &>>=(instance: inout Self, distance: Swift.Int) {
         instance &>>= IX(distance)
@@ -287,9 +295,9 @@ extension SystemsInteger {
     
     /// Performs a descending masked shift.
     ///
-    /// - Note: The filler bit is either `0` (up) or `appendix` (down).
+    /// ### Binary Integer Shift
     ///
-    /// - Note: The default integer literal is `Swift.Int`.
+    /// - Note: The filler bit is either `0` (up) or `appendix` (down).
     ///
     @inlinable public static func &>>(instance: consuming Self, distance: Swift.Int) -> Self {
         instance &>>  IX(distance)

--- a/Sources/CoreKit/BinaryInteger+Values.swift
+++ b/Sources/CoreKit/BinaryInteger+Values.swift
@@ -108,7 +108,7 @@ extension SystemsInteger where BitPattern == UX.BitPattern {
     /// - Important: A binary integer's `size` is measured in bits.
     ///
     @inlinable public init?<Other>(size type: Other.Type) where Other: BinaryInteger {
-        if  Other.size.isInfinite {
+        if  Other.isArbitrary {
             return nil
         }   else {
             self.init(load: UX(raw: Other.size))

--- a/Sources/CoreKit/BinaryInteger.swift
+++ b/Sources/CoreKit/BinaryInteger.swift
@@ -284,21 +284,17 @@ where
     
     /// Performs an ascending shift.
     ///
-    /// - Parameter distance: A shift in the range of `0 ..< Self.size`.
+    /// ### Binary Integer Shift
     ///
     /// - Note: The filler bit is either `0` (up) or `appendix` (down).
-    ///
-    /// - Note: A `distance` greater than `IX.max` is a directional flush.
     ///
     @inlinable consuming func up(_ distance: Shift<Magnitude>) -> Self
     
     /// Performs a decending shift.
     ///
-    /// - Parameter distance: A shift in the range of `0 ..< Self.size`.
+    /// ### Binary Integer Shift
     ///
     /// - Note: The filler bit is either `0` (up) or `appendix` (down).
-    ///
-    /// - Note: A `distance` greater than `IX.max` is a directional flush.
     ///
     @inlinable consuming func down(_ distance: Shift<Magnitude>) -> Self
     

--- a/Sources/InfiniIntIop/InfiniInt+Shift.swift
+++ b/Sources/InfiniIntIop/InfiniInt+Shift.swift
@@ -25,9 +25,6 @@ extension InfiniInt.Stdlib {
     }
     
     @inlinable public static func <<(instance: consuming Self, distance: some Swift.BinaryInteger) -> Self {
-        //=--------------------------------------=
-        // note: Int.min is down so this is fine
-        //=--------------------------------------=
         Self(instance.base << IX(Swift.Int(clamping: distance)))
     }
     
@@ -36,17 +33,6 @@ extension InfiniInt.Stdlib {
     }
     
     @inlinable public static func >>(instance: consuming Self, distance: some Swift.BinaryInteger) -> Self {
-        //=--------------------------------------=
-        // note: standard library semantics
-        //=--------------------------------------=
-        let distance =  Swift.Int(clamping: distance)
-        if  distance == Swift.Int.min {
-            //=----------------------------------=
-            // note: base semantics (#140)
-            //=----------------------------------=
-            precondition(instance.base.isZero, String.overallocation())
-        }
-        
-        return Self(instance.base >> IX(distance))
+        Self(instance.base >> IX(Swift.Int(clamping: distance)))
     }
 }

--- a/Sources/InfiniIntKit/InfiniInt+Shift.swift
+++ b/Sources/InfiniIntKit/InfiniInt+Shift.swift
@@ -28,7 +28,10 @@ extension InfiniInt {
             return self as Self as Self as Self
             
         }   else {
-            return Self.zero // flush >= IX.max as per protocol
+            let zeros = UX(raw: self.ascending(Bit.zero))
+            let index = UX(raw: distance.value).toggled()
+            precondition(zeros  >= index, String.overallocation())
+            return Self.zero // overshift of all nonzero bits
         }
     }
     
@@ -41,7 +44,7 @@ extension InfiniInt {
             return self as Self as Self as Self
             
         }   else {
-            return Self(repeating: self.appendix) // flush >= IX.max as per protocol
+            return Self(repeating: self.appendix)
         }
     }
 }

--- a/Sources/InfiniIntKit/InfiniInt+Shift.swift
+++ b/Sources/InfiniIntKit/InfiniInt+Shift.swift
@@ -28,9 +28,11 @@ extension InfiniInt {
             return self as Self as Self as Self
             
         }   else {
+            // compute how many bits stay in the low part
+            let (low) = UX(raw: distance.value).toggled()
             let zeros = UX(raw: self.ascending(Bit.zero))
-            let index = UX(raw: distance.value).toggled()
-            precondition(zeros  >= index, String.overallocation())
+            Swift.assert(low <= IX.max)
+            precondition(low <= zeros, String.overallocation())
             return Self.zero // overshift of all nonzero bits
         }
     }

--- a/Sources/TestKit/Models/Tag.swift
+++ b/Sources/TestKit/Models/Tag.swift
@@ -16,7 +16,7 @@ extension Tag {
     //=------------------------------------------------------------------------=
     // MARK: Metadata
     //=------------------------------------------------------------------------=
-    
+        
     /// Removing uncertainty of meaning.
     @Tag public static var disambiguation: Self
     
@@ -25,6 +25,9 @@ extension Tag {
     
     /// Including or considering all arguments.
     @Tag public static var exhaustive: Self
+    
+    /// Process or program termination.
+    @Tag public static var exit: Self
     
     /// Sending to another destination.
     @Tag public static var forwarding: Self

--- a/Tests/UltimathnumTests/BinaryInteger+Shift.swift
+++ b/Tests/UltimathnumTests/BinaryInteger+Shift.swift
@@ -99,6 +99,369 @@ import TestKit
 }
 
 //*============================================================================*
+// MARK: * Binary Integer x Shift x Edge Cases
+//*============================================================================*
+
+@Suite struct BinaryIntegerTestsOnShiftEdgeCases {
+    
+    //=------------------------------------------------------------------------=
+    // MARK: Tests
+    //=------------------------------------------------------------------------=
+    
+    @Test(
+        "BinaryInteger/shift/edge-cases: nonshift",
+        Tag.List.tags(.generic, .random),
+        arguments: typesAsBinaryInteger, fuzzers
+    )   func nonshift(
+        type: any BinaryInteger.Type, randomness: consuming FuzzerInt
+    )   throws {
+        
+        try  whereIs(type)
+        func whereIs<T>(_ type: T.Type) throws where T: BinaryInteger {
+            for _ in 0 ..< 32 {
+                let index = Shift<T.Magnitude>.max(or: 255)
+                let value = T.entropic(through: index, using: &randomness)
+                try #require(value == value.up  (Count.zero))
+                try #require(value == value.down(Count.zero))
+                try #require(value == value.up  (Shift.min ))
+                try #require(value == value.down(Shift.min ))
+            }
+        }
+    }
+    
+    @Test(
+        "BinaryInteger/shift/edge-cases: down by distance near nonappendix count",
+        Tag.List.tags(.generic, .important, .random),
+        arguments: typesAsBinaryInteger, fuzzers
+    )   func downByDistanceNearNonappendixCount(
+        type: any BinaryInteger.Type, randomness: consuming FuzzerInt
+    )   throws {
+        
+        try  whereIs(type)
+        func whereIs<T>(_ type: T.Type) throws where T: BinaryInteger {
+            for _ in 0 ..< 256 {
+                let index = Shift<T.Magnitude>.max(or: 255)
+                let value = T.entropic(through: index, using: &randomness)
+                let nonappendix = IX(raw: value.nondescending(value.appendix))
+                let overshifted = T(repeating: value.appendix)
+                
+                if  let distance = Count.exactly(nonappendix - 1)?.optional() {
+                    try #require(value.down(distance) == (overshifted ^ 1))
+                }
+                
+                try #require(value.down(Count(nonappendix    )) == overshifted)
+                try #require(value.down(Count(nonappendix + 1)) == overshifted)
+            }
+        }
+    }
+    
+    @Test(
+        "BinaryInteger/shift/edge-cases: up by distance to start of next element",
+        Tag.List.tags(.generic, .important, .random),
+        arguments: typesAsBinaryInteger, fuzzers
+    )   func upByDistanceToStartOfNextElement(
+        type: any BinaryInteger.Type, randomness: consuming FuzzerInt
+    )   throws {
+        
+        try  whereIs(type)
+        func whereIs<T>(_ type: T.Type) throws where T: BinaryInteger {
+            for _ in 0 ..< conditional(debug: 8, release: 32) {
+                let index = Shift<T.Magnitude>.max(or: 255)
+                let value = T.entropic(through: index, using: &randomness)
+                var expectation = value
+                
+                for distance in 0 ... IX(size: T.Element.self) {
+                    try #require((expectation) == value.up(Count(distance)))
+                    expectation = expectation.plus(expectation).value
+                }
+            }
+        }
+    }
+}
+
+//*============================================================================*
+// MARK: * Binary Integer x Shift x Overshifts
+//*============================================================================*
+
+@Suite struct BinaryIntegerTestsOnShiftOvershifts {
+    
+    //=------------------------------------------------------------------------=
+    // MARK: Tests x Distance is Count or Shift
+    //=------------------------------------------------------------------------=
+    
+    @Test(
+        "BinaryInteger/shift/overshifts: Count or Shift ∈ ℕ",
+        Tag.List.tags(.generic, .random),
+        arguments: typesAsSystemsInteger, fuzzers
+    )   func distanceIsFiniteCountOrShift(
+        type: any SystemsInteger.Type, randomness: consuming FuzzerInt
+    )   throws {
+       
+        try  whereIs(type)
+        func whereIs<T>(_ type: T.Type) throws where T: SystemsInteger {
+            let size = IX(size: T.self)
+            
+            for _ in 0 ..< conditional(debug: 8, release: 32) {
+                let value = T.entropic(using: &randomness)
+                let distance = Count(raw: IX.random(in: size...IX.max, using: &randomness))
+                
+                try #require(!distance.isInfinite)
+                try #require(value.up  (Count(raw: distance)).isZero)
+                try #require(value.down(Count(raw: distance)) == T(repeating: value.appendix))
+                
+                if  let distance = Shift<T.Magnitude>(exactly: distance) {
+                    try #require(value.up  (distance).isZero)
+                    try #require(value.down(distance) == T(repeating: value.appendix))
+                }
+            }
+        }
+    }
+    
+    @Test(
+        "BinaryInteger/shift/overshifts: Count or Shift ∉ ℕ",
+        Tag.List.tags(.generic, .random),
+        arguments: typesAsBinaryInteger, fuzzers
+    )   func distanceIsInfiniteCountOrShift(
+        type: any BinaryInteger.Type, randomness: consuming FuzzerInt
+    )   throws {
+       
+        try  whereIs(type)
+        func whereIs<T>(_ type: T.Type) throws where T: BinaryInteger {
+            for _ in 0 ..< 32 {
+                let value = T.entropic(through: Shift.max(or: 255), using: &randomness)
+                let zeros = UX(raw:  value.ascending(Bit.zero))
+                let limit = UX.max - zeros
+                let distance = Count(raw: UX.random(in: limit...UX.max, using: &randomness))
+                
+                try #require(distance.isInfinite)
+                try #require(value.up  (Count(raw: distance)).isZero)
+                try #require(value.down(Count(raw: distance)) == T(repeating: value.appendix))
+                
+                if  let distance = Shift<T.Magnitude>(exactly: distance) {
+                    try #require(value.up  (distance).isZero)
+                    try #require(value.down(distance) == T(repeating: value.appendix))
+                }
+            }
+        }
+    }
+    
+    //=------------------------------------------------------------------------=
+    // MARK: Tests x Distance is Binary Integer
+    //=------------------------------------------------------------------------=
+    
+    @Test(
+        "BinaryInteger/shift/overshifts: T.size ≤ |distance| ≤ IX.max",
+        Tag.List.tags(.generic, .random),
+        arguments: typesAsSystemsInteger, fuzzers
+    )   func distanceWhereMagnitudeIsFromSizeThroughLimitAsBinaryInteger(
+        type: any SystemsInteger.Type, randomness: consuming FuzzerInt
+    )   throws {
+        
+        for distance in typesAsBinaryInteger {
+            try whereIs(type, distance: distance)
+        }
+        
+        func whereIs<T, U>(_ type: T.Type, distance: U.Type)
+        throws where T: SystemsInteger, U: BinaryInteger {
+            
+            if  let min = U.exactly(IX(size: T.self)).optional() {
+                let max = U(clamping: IX.max)
+                
+                for _ in 0 ..< conditional(debug: 8, release: 32) {
+                    let value    = T.entropic(using: &randomness)
+                    let distance = U.random(in: min...max, using: &randomness)
+                    
+                    try #require((value << distance).isZero)
+                    try #require((value >> distance)  == T(repeating: value.appendix))
+                }
+            }
+
+            if  let max = U.exactly(IX(size: T.self).complement()).optional() {
+                let min = U(clamping: IX.max.complement())
+                
+                for _ in 0 ..< conditional(debug: 8, release: 32) {
+                    let value    = T.entropic(using: &randomness)
+                    let distance = U.random(in: min...max, using: &randomness)
+                    
+                    try #require((value << distance)  == T(repeating: value.appendix))
+                    try #require((value >> distance).isZero)
+                }
+            }
+        }
+    }
+    
+    @Test(
+        "BinaryInteger/shift/overshifts: distance ∈ ℤ where |distance| > IX.max",
+        Tag.List.tags(.generic, .random),
+        arguments: typesAsBinaryInteger, fuzzers
+    )   func distanceIsFiniteWhereMagnitudeIsGreaterThanLimitAsBinaryInteger(
+        type: any BinaryInteger.Type, randomness: consuming FuzzerInt
+    )   throws {
+        
+        for distance in typesAsBinaryInteger {
+            try whereIs(type, distance: distance)
+        }
+        
+        func whereIs<T, U>(_ type: T.Type, distance: U.Type)
+        throws where T: BinaryInteger, U: BinaryInteger {
+            
+            if  let min = U.exactly(UX.msb).optional() {
+                let max = U(clamping: IXL(Array(repeating: U64.max, count: 4)))
+                
+                for _ in 0 ..< conditional(debug: 8, release: 32) {
+                    let index = Shift<T.Magnitude>.max(or: 255)
+                    let value = T.entropic(through: index, using: &randomness)
+                    let distance = U.random(in: min...max, using: &randomness)
+                    
+                    if !T.isArbitrary || value.isZero {
+                        try #require((value << distance).isZero)
+                    }
+                    
+                    always: do {
+                        try #require((value >> distance) == T(repeating: value.appendix))
+                    }
+                }
+            }
+            
+            if  let max = U.exactly(IX.min).optional() {
+                let min = U(clamping: IXL(Array(repeating: U64.max, count: 4)).negated())
+                
+                for _ in 0 ..< conditional(debug: 8, release: 32) {
+                    let index = Shift<T.Magnitude>.max(or: 255)
+                    let value = T.entropic(through: index, using: &randomness)
+                    let distance = U.random(in: min...max, using: &randomness)
+                    
+                    always: do {
+                        try #require((value << distance) == T(repeating: value.appendix))
+                    }
+                    
+                    if !T.isArbitrary || value.isZero {
+                        try #require((value >> distance).isZero)
+                    }
+                }
+            }
+        }
+    }
+    
+    @Test(
+        "BinaryInteger/shift/overshifts: distance ∉ ℤ",
+        Tag.List.tags(.generic, .random),
+        arguments: typesAsBinaryInteger, fuzzers
+    )   func distanceIsInfiniteAsBinaryInteger(
+        type: any BinaryInteger.Type, randomness: consuming FuzzerInt
+    )   throws {
+        
+        for distance in typesAsArbitraryIntegerAsUnsigned {
+            try whereIs(type, distance)
+        }
+
+        func whereIs<T, U>(_ type: T.Type, _ other: U.Type)
+        throws where T: BinaryInteger, U: ArbitraryIntegerAsUnsigned {
+            for _ in 0 ..< 32 {
+                let value    = T.entropic(through: Shift.max(or: 255), using: &randomness)
+                let distance = U.entropic(through: Shift.max(or: 255), as: Domain.natural, using: &randomness).toggled()
+
+                try #require(distance.isInfinite)
+                try #require((value << distance).isZero)
+                try #require((value >> distance) == T(repeating: value.appendix))
+            }
+        }
+    }
+}
+
+//*============================================================================*
+// MARK: * Binary Integer x Shift x Overallocations
+//*============================================================================*
+
+@Suite struct BinaryIntegerTestsOnShiftOverallocations {
+    
+    //=------------------------------------------------------------------------=
+    // MARK: Tests x Distance is Count or Shift
+    //=------------------------------------------------------------------------=
+    
+    @Test(
+        "BinaryInteger/shift/overallocations: Count or Shift ∉ ℤ (req. exit test)",
+        Tag.List.tags(.documentation, .exit, .generic, .todo),
+        arguments: typesAsArbitraryInteger
+    )   func distanceIsInfiniteAsCountOrShift(
+        type: any ArbitraryInteger.Type
+    )   throws {
+        
+        try  whereIs(type)
+        func whereIs<T>(_ type: T.Type) throws where T: ArbitraryInteger {
+            try yay( 0b01, up: Count(raw: UX.max - 0))
+//          try nay( 0b01, up: Count(raw: UX.max - 1))
+            
+            try yay( 0b10, up: Count(raw: UX.max - 0))
+            try yay( 0b10, up: Count(raw: UX.max - 1))
+//          try nay( 0b10, up: Count(raw: UX.max - 1))
+            
+            try yay(~0b00, up: Count(raw: UX.max - 0))
+//          try nay(~0b00, up: Count(raw: UX.max - 1))
+            
+            try yay(~0b01, up: Count(raw: UX.max - 0))
+            try yay(~0b01, up: Count(raw: UX.max - 1))
+//          try nay(~0b01, up: Count(raw: UX.max - 2))
+            
+            func yay(_ value: T, up count: Count) throws {
+                try #require(value.up(count).isZero)
+                
+                if  let shift = Shift<T.Magnitude>(exactly: count) {
+                    try #require(value.up(shift).isZero)
+                }
+            }
+            
+            func nay(_ value: T, up count: Count) throws {
+                _ = value.up(count) // TODO: req. exit test
+                
+                if  let shift = Shift<T.Magnitude>(exactly: count) {
+                    _ = value.up(shift)
+                }
+            }
+        }
+    }
+    
+    //=----------------------------------------------------------------------------=
+    // MARK: Tests x Distance is Binary Integer
+    //=----------------------------------------------------------------------------=
+    
+    @Test(
+        "BinaryInteger/shift/overallocations: BinaryInteger ∈ ℤ (req. exit test)",
+        Tag.List.tags(.documentation, .exit, .generic, .todo),
+        arguments: typesAsArbitraryInteger, fuzzers
+    )   func distanceIsFiniteAsBinaryInteger(
+        type: any ArbitraryInteger.Type, randomness: consuming FuzzerInt
+    )   throws {
+        
+        for distance in typesAsBinaryInteger {
+            try  whereIs(type, distance: distance)
+        }
+        
+        func whereIs<T, U>(_ type: T.Type, distance: U.Type)
+        throws where T: ArbitraryInteger, U: BinaryInteger {
+            
+//          if  let distance = U.exactly(UX.msb).optional() {
+//              let value = T.entropic(size: 256, using: &randomness)
+//              try nay(value, up:   distance)
+//          }
+
+//          if  let distance = U.exactly(IX.min).optional() {
+//              let value = T.entropic(size: 256, using: &randomness)
+//              try nay(value, down: distance)
+//          }
+            
+            func nay(_ value: T, up   distance: U) throws {
+                _ = value << distance // TODO: req. exit test
+            }
+            
+            func nay(_ value: T, down distance: U) throws {
+                _ = value >> distance // TODO: req. exit test
+            }
+        }
+    }
+}
+
+//*============================================================================*
 // MARK: * Binary Integer x Shift x Conveniences
 //*============================================================================*
 
@@ -244,293 +607,6 @@ import TestKit
                 let expectation = random.up(Shift<T.Magnitude>(Count(distance)))
                 try #require(expectation == reduce(random, >>,  U(-distance)))
                 try #require(expectation == reduce(random, >>=, U(-distance)))
-            }
-        }
-    }
-}
-
-//*============================================================================*
-// MARK: * Binary Integer x Shift x Edge Cases
-//*============================================================================*
-
-@Suite struct BinaryIntegerTestsOnShiftEdgeCases {
-    
-    //=------------------------------------------------------------------------=
-    // MARK: Tests
-    //=------------------------------------------------------------------------=
-    
-    @Test(
-        "BinaryInteger/shift/edge-cases: distance of zero yields input",
-        Tag.List.tags(.generic, .random),
-        arguments: typesAsBinaryInteger, fuzzers
-    )   func distanceOfZeroYieldsInput(
-        type: any BinaryInteger.Type, randomness: consuming FuzzerInt
-    )   throws {
-        
-        try  whereIs(type)
-        func whereIs<T>(_ type: T.Type) throws where T: BinaryInteger {
-            for _ in 0 ..< 32 {
-                let random = T.entropic(through: Shift.max(or: 255), using: &randomness)
-                try #require(random == random.up  (Count.zero))
-                try #require(random == random.down(Count.zero))
-                try #require(random == random.up  (Shift.min ))
-                try #require(random == random.down(Shift.min ))
-            }
-        }
-    }
-    
-    @Test(
-        "BinaryInteger/shift/edge-cases: down by distance near nonappendix count",
-        Tag.List.tags(.generic, .important, .random),
-        arguments: typesAsBinaryInteger, fuzzers
-    )   func downByDistanceNearNonappendixCount(
-        type: any BinaryInteger.Type, randomness: consuming FuzzerInt
-    )   throws {
-        
-        try  whereIs(type)
-        func whereIs<T>(_ type: T.Type) throws where T: BinaryInteger {
-            for _ in 0 ..< 256 {
-                let random = T.entropic(through: Shift.max(or: 255), using: &randomness)
-                let nonappendix = IX(raw: random.nondescending(random.appendix))
-                let overshifted = T(repeating: random.appendix)
-                
-                if  let distance = Count.exactly(nonappendix - 1)?.optional() {
-                    try #require(random.down(distance) == (overshifted ^ 1))
-                }
-                
-                try #require(random.down(Count(nonappendix    )) == overshifted)
-                try #require(random.down(Count(nonappendix + 1)) == overshifted)
-            }
-        }
-    }
-    
-    @Test(
-        "BinaryInteger/shift/edge-cases: up by distance to start of next element",
-        Tag.List.tags(.generic, .important, .random),
-        arguments: typesAsBinaryInteger, fuzzers
-    )   func upByDistanceToStartOfNextElement(
-        type: any BinaryInteger.Type, randomness: consuming FuzzerInt
-    )   throws {
-        
-        try  whereIs(type)
-        func whereIs<T>(_ type: T.Type) throws where T: BinaryInteger {
-            for _ in 0 ..< conditional(debug: 8, release: 32) {
-                let random = T.entropic(through: Shift.max(or: 255), using: &randomness)
-                var expectation = random
-                
-                for distance in 0 ... IX(size:T.Element.self) {
-                    try #require((expectation) == random.up(Count(distance)))
-                    expectation = expectation.plus(expectation).value
-                }
-            }
-        }
-    }
-    
-    //=------------------------------------------------------------------------=
-    // MARK: Tests x |distance| > (size) is overshift
-    //=------------------------------------------------------------------------=
-    
-    @Test(
-        "BinaryInteger/shift/edge-cases: overshift by Count or Shift in ±[size, IX.max]",
-        Tag.List.tags(.generic, .random),
-        arguments: typesAsSystemsInteger, fuzzers
-    )   func overshiftByCountOrShiftFromSizeThroughLimit(
-        type: any SystemsInteger.Type, randomness: consuming FuzzerInt
-    )   throws {
-       
-        try  whereIs(type)
-        func whereIs<T>(_ type: T.Type) throws where T: SystemsInteger {
-            let size = IX(size: T.self)
-            
-            for _ in 0 ..< conditional(debug: 8, release: 32) {
-                let random   = T.entropic(through: Shift.max(or: 255), using: &randomness)
-                let distance = Count(raw: IX.random(in: size...IX.max, using: &randomness))
-                
-                try #require(random.up  (Count(raw: distance)).isZero)
-                try #require(random.down(Count(raw: distance)) == T(repeating: random.appendix))
-                
-                if  let distance = Shift<T.Magnitude>(exactly: distance) {
-                    try #require(random.up  (distance).isZero)
-                    try #require(random.down(distance) == T(repeating: random.appendix))
-                }
-            }
-        }
-    }
-    
-    @Test(
-        "BinaryInteger/shift/edge-cases: overshift by positive distance in ±[size, IX.max]",
-        Tag.List.tags(.generic, .random),
-        arguments: typesAsSystemsInteger, fuzzers
-    )   func overshiftByPositiveDistanceFromSizeThroughLimit(
-        type: any SystemsInteger.Type, randomness: consuming FuzzerInt
-    )   throws {
-        
-        for distance in typesAsBinaryInteger {
-            try whereIs(type, distance)
-        }
-        
-        func whereIs<T, U>(_ type: T.Type, _ other: U.Type)
-        throws where T: SystemsInteger, U: BinaryInteger {
-            guard let min = U.exactly(IX(size: T.self)).optional() else { return }
-            let max = U(clamping: IX.max)
-            
-            for _ in 0 ..< conditional(debug: 8, release: 32) {
-                let random   = T.entropic(through: Shift.max(or: 255), using: &randomness)
-                let distance = U.random(in: min...max, using: &randomness)
-
-                try #require(distance.isPositive)
-                try #require(distance.magnitude() >= IX(size: T.self))
-                try #require(distance.magnitude() <= IX.max)
-                try #require((random << distance).isZero)
-                try #require((random >> distance) == T(repeating: random.appendix))
-            }
-        }
-    }
-    
-    @Test(
-        "BinaryInteger/shift/edge-cases: overshift by negative distance in ±[size, IX.max]",
-        Tag.List.tags(.generic, .random),
-        arguments: typesAsSystemsInteger, fuzzers
-    )   func overshiftByNegativeDistanceFromSizeThroughLimit(
-        type: any SystemsInteger.Type, randomness: consuming FuzzerInt
-    )   throws {
-        
-        for distance in typesAsBinaryInteger {
-            try whereIs(type, distance)
-        }
-        
-        func whereIs<T, U>(_ type: T.Type, _ other: U.Type)
-        throws where T: SystemsInteger, U: BinaryInteger {
-            guard let max = U.exactly(-IX(size: T.self)).optional() else { return }
-            let min = U(clamping: -IX.max)
-            
-            for _ in 0 ..< conditional(debug: 8, release: 32) {
-                let random   = T.entropic(through: Shift.max(or: 255), using: &randomness)
-                let distance = U.random(in: min...max, using: &randomness)
-                
-                try #require(distance.isNegative)
-                try #require(distance.magnitude() >= IX(size: T.self))
-                try #require(distance.magnitude() <= IX.max)
-                try #require((random << distance) == T(repeating: random.appendix))
-                try #require((random >> distance).isZero)
-            }
-        }
-    }
-    
-    //=------------------------------------------------------------------------=
-    // MARK: Tests x |distance| > IX.max is overshift (by protocol)
-    //=------------------------------------------------------------------------=
-    
-    @Test(
-        "BinaryInteger/shift/edge-cases: overshift by positive distance in ±(IX.max, ∞)",
-        Tag.List.tags(.generic, .random),
-        arguments: typesAsBinaryInteger, fuzzers
-    )   func overshiftByPositiveDistanceGreaterThanLimit(
-        type: any BinaryInteger.Type, randomness: consuming FuzzerInt
-    )   throws {
-        
-        for distance in typesAsBinaryInteger {
-            try whereIs(type, distance)
-        }
-        
-        func whereIs<T, U>(_ type: T.Type, _ other: U.Type)
-        throws where T: BinaryInteger, U: BinaryInteger {
-            guard let min = U.exactly(UX.msb).optional() else { return }
-            let max = U(clamping: IXL(Array(repeating: U64.max, count: 4)))
-            
-            for _ in 0 ..< conditional(debug: 8, release: 32) {
-                let random   = T.entropic(through: Shift.max(or: 255), using: &randomness)
-                let distance = U.random(in: min...max, using: &randomness)
-                
-                try #require(distance.isInfinite  == false)
-                try #require(distance.magnitude() > IX.max)
-                try #require((random << distance).isZero)
-                try #require((random >> distance) == T(repeating: random.appendix))
-            }
-        }
-    }
-    
-    @Test(
-        "BinaryInteger/shift/edge-cases: overshift by negative distance in ±(IX.max, ∞)",
-        Tag.List.tags(.generic, .random),
-        arguments: typesAsBinaryInteger, fuzzers
-    )   func overshiftByNegativeDistanceGreaterThanLimit(
-        type: any BinaryInteger.Type, randomness: consuming FuzzerInt
-    )   throws {
-        
-        for distance in typesAsBinaryInteger {
-            try whereIs(type, distance)
-        }
-        
-        func whereIs<T, U>(_ type: T.Type, _ other: U.Type) throws where T: BinaryInteger, U: BinaryInteger {
-            guard let max = U.exactly(IX.min).optional() else { return }
-            let min = U(clamping:-IXL(Array(repeating: U64.max, count: 4)))
-            
-            for _ in 0 ..< conditional(debug: 8, release: 32) {
-                let random   = T.entropic(through: Shift.max(or: 255), using: &randomness)
-                let distance = U.random(in: min...max, using: &randomness)
-                
-                try #require(distance.isInfinite  == false)
-                try #require(distance.magnitude() > IX.max)
-                try #require((random << distance) == T(repeating: random.appendix))
-                try #require((random >> distance).isZero)
-            }
-        }
-    }
-    
-    //=------------------------------------------------------------------------=
-    // MARK: Tests x |distance| > IX.max is overshift (by protocol)
-    //=------------------------------------------------------------------------=
-    
-    @Test(
-        "BinaryInteger/shift/edge-cases: overshift by infinite Count or Shift",
-        Tag.List.tags(.generic, .random),
-        arguments: typesAsBinaryInteger, fuzzers
-    )   func overshiftByInfiniteCountOrShift(
-        type: any BinaryInteger.Type, randomness: consuming FuzzerInt
-    )   throws {
-       
-        try  whereIs(type)
-        func whereIs<T>(_ type: T.Type) throws where T: BinaryInteger {
-            for _ in 0 ..< 32 {
-                let random   = T.entropic(through: Shift.max(or: 255), using: &randomness)
-                let distance = Count(raw: IX.random(in:  IX.negatives, using: &randomness)!)
-                
-                try #require(distance.isInfinite)
-                try #require(random.up  (Count(raw: distance)).isZero)
-                try #require(random.down(Count(raw: distance)) == T(repeating: random.appendix))
-                
-                if  let distance = Shift<T.Magnitude>(exactly: distance) {
-                    try #require(T.isArbitrary)
-                    try #require(distance.isInfinite)
-                    try #require(random.up  (distance).isZero)
-                    try #require(random.down(distance) == T(repeating: random.appendix))
-                }
-            }
-        }
-    }
-    
-    @Test(
-        "BinaryInteger/shift/edge-cases: overshift by infinite ArbitraryInteger",
-        Tag.List.tags(.generic, .random),
-        arguments: typesAsBinaryInteger, fuzzers
-    )   func overshiftByInfiniteArbitraryInteger(
-        type: any BinaryInteger.Type, randomness: consuming FuzzerInt
-    )   throws {
-        
-        for distance in typesAsArbitraryIntegerAsUnsigned {
-            try whereIs(type, distance)
-        }
-
-        func whereIs<T, U>(_ type: T.Type, _ other: U.Type)
-        throws where T: BinaryInteger, U: ArbitraryIntegerAsUnsigned {
-            for _ in 0 ..< 32 {
-                let random   = T.entropic(through: Shift.max(or: 255), using: &randomness)
-                let distance = U.entropic(through: Shift.max(or: 255), as: Domain.natural, using: &randomness).toggled()
-
-                try #require(distance.isInfinite)
-                try #require((random << distance).isZero)
-                try #require((random >> distance) == T(repeating: random.appendix))
             }
         }
     }


### PR DESCRIPTION
This patch introduces proper over-allocating shifts (#140).

Ascending shift distances in the range `IX.max + 1 ..< T.size` are now well-behaved (but not recoverable).