### PR TITLE
Add: T/isPowerOf2

### DIFF
--- a/Sources/CoreKit/BinaryInteger+Comparison.swift
+++ b/Sources/CoreKit/BinaryInteger+Comparison.swift
@@ -68,6 +68,18 @@ extension BinaryInteger {
         }
     }
     
+    /// Indicates whether this value is a power of `2`
+    @inlinable public var isPowerOf2: Bool {
+        if  Self.size == Element.size {
+            return self.isPositive && (self & (self &- 1)).isZero
+            
+        }   else {
+            return self.withUnsafeBinaryIntegerElements {
+                $0.isPowerOf2
+            }
+        }
+    }
+    
     /// Performs a three-way comparison of `self` versus `zero`.
     ///
     /// - Note: Big integers evaluate it in place, cf. `compared(to: 0)`.
@@ -82,6 +94,10 @@ extension BinaryInteger {
             }
         }
     }
+    
+    //=------------------------------------------------------------------------=
+    // MARK: Utilities
+    //=------------------------------------------------------------------------=
     
     /// Hashes the normalized 8-bit data integer elements of `self`.
     ///

--- a/Sources/CoreKit/Models/DataInt+Comparison.swift
+++ b/Sources/CoreKit/Models/DataInt+Comparison.swift
@@ -17,6 +17,11 @@ extension DataInt {
     // MARK: Utilities
     //=------------------------------------------------------------------------=
     
+    /// Indicates whether the `body` is free of `appendix` extensions.
+    @inlinable public var isNormal: Bool {
+        self.body.last != self.last
+    }
+    
     /// Indicates whether this value is equal to zero.
     ///
     /// - Note: This comparison is performed backwards.
@@ -25,9 +30,13 @@ extension DataInt {
         !Bool(self.appendix) && self.body.isZero
     }
     
-    /// Indicates whether the `body` is free of `appendix` extensions.
-    @inlinable public var isNormal: Bool {
-        self.body.last != self.last
+    /// Indicates whether this value is a power of `2`
+    @inlinable public var isPowerOf2: Bool {
+        if  Bool(self.appendix) {
+            return false
+        }   else {
+            return self.body.isPowerOf2
+        }
     }
 }
 
@@ -174,12 +183,14 @@ extension DataInt.Body {
     // MARK: Utilities
     //=------------------------------------------------------------------------=
     
-    /// Indicates whether this value is equal to zero.
+    /// Indicates whether this buffer is empty.
     ///
-    /// - Note: This comparison is performed backwards.
+    /// An empty buffer lacks valid subscript arguments.
     ///
-    @inlinable public var isZero: Bool {
-        self.buffer().reversed().allSatisfy({ $0.isZero })
+    /// - Invariant: `self.isEmpty == self.count.isZero`
+    ///
+    @inlinable public var isEmpty: Bool {
+        self.count.isZero
     }
     
     /// Indicates whether the `body` is free of `appendix` extensions.
@@ -190,14 +201,25 @@ extension DataInt.Body {
         DataInt(self).isNormal
     }
     
-    /// Indicates whether this buffer is empty.
+    /// Indicates whether this value is equal to zero.
     ///
-    /// An empty buffer lacks valid subscript arguments.
+    /// - Note: This comparison is performed backwards.
     ///
-    /// - Invariant: `self.isEmpty == self.count.isZero`
-    ///
-    @inlinable public var isEmpty: Bool {
-        self.count.isZero
+    @inlinable public var isZero: Bool {
+        self.buffer().reversed().allSatisfy({ $0.isZero })
+    }
+    
+    /// Indicates whether this value is a power of `2`
+    @inlinable public var isPowerOf2: Bool {
+        var element = Element()
+        
+        for next in self.buffer() {
+            guard !(next).isZero else { continue }
+            guard element.isZero else { return false }
+            element = next
+        }
+        
+        return element.isPowerOf2
     }
     
     /// Performs a three-way comparison of `self` versus `zero`.
@@ -229,14 +251,19 @@ extension MutableDataInt {
     // MARK: Utilities
     //=------------------------------------------------------------------------=
     
+    /// Indicates whether the `body` is free of `appendix` extensions.
+    @inlinable public var isNormal: Bool {
+        Immutable(self).isNormal
+    }
+    
     /// Indicates whether this value is equal to zero.
     @inlinable public var isZero: Bool {
         Immutable(self).isZero
     }
     
-    /// Indicates whether the `body` is free of `appendix` extensions.
-    @inlinable public var isNormal: Bool {
-        Immutable(self).isNormal
+    /// Indicates whether this value is a power of `2`
+    @inlinable public var isPowerOf2: Bool {
+        Immutable(self).isPowerOf2
     }
 }
 
@@ -249,19 +276,6 @@ extension MutableDataInt.Body {
     //=------------------------------------------------------------------------=
     // MARK: Utilities
     //=------------------------------------------------------------------------=
-        
-    /// Indicates whether this value is equal to zero.
-    @inlinable public var isZero: Bool {
-        Immutable(self).isZero
-    }
-    
-    /// Indicates whether the `body` is free of `appendix` extensions.
-    ///
-    /// - Note: The `appendix` of a binary integer `body` is always `zero`.
-    ///
-    @inlinable public var isNormal: Bool {
-        Immutable(self).isNormal
-    }
     
     /// Indicates whether this buffer is empty.
     ///
@@ -271,6 +285,24 @@ extension MutableDataInt.Body {
     ///
     @inlinable public var isEmpty: Bool {
         Immutable(self).isEmpty
+    }
+    
+    /// Indicates whether the `body` is free of `appendix` extensions.
+    ///
+    /// - Note: The `appendix` of a binary integer `body` is always `zero`.
+    ///
+    @inlinable public var isNormal: Bool {
+        Immutable(self).isNormal
+    }
+        
+    /// Indicates whether this value is equal to zero.
+    @inlinable public var isZero: Bool {
+        Immutable(self).isZero
+    }
+    
+    /// Indicates whether this value is a power of `2`
+    @inlinable public var isPowerOf2: Bool {
+        Immutable(self).isPowerOf2
     }
     
     //=------------------------------------------------------------------------=

--- a/Tests/UltimathnumTests/BinaryInteger+Comparison.swift
+++ b/Tests/UltimathnumTests/BinaryInteger+Comparison.swift
@@ -43,6 +43,56 @@ import TestKit
         }
     }
     
+    @Test(
+        "BinaryInteger/comparison: isPowerOf2",
+        Tag.List.tags(.generic, .random),
+        arguments: typesAsBinaryInteger, fuzzers
+    )   func isPowerOf2(
+        type: any BinaryInteger.Type, randomness: consuming FuzzerInt
+    )   throws {
+        
+        try  whereIs(type)
+        func whereIs<T>(_ type: T.Type) throws where T: BinaryInteger {
+            let size = IX(size: T.self) ?? 256
+            
+            for index in 0 ..< size {
+                let value = T.lsb.up(Count(index))
+                try whereIs( value, expectation: !T.isCompact || (index + 1 < size))
+                try whereIs(~value, expectation: false)
+            }
+            
+            for _ in 0 ..< 32 {
+                let value = T.entropic(size: size, using: &randomness)
+                let expectation = value.isPositive && value.count(Bit.one) == Count(1)
+                try whereIs(value, expectation: expectation)
+            }
+            
+            func whereIs(_ value: consuming T, expectation: Bool) throws {
+                try #require(expectation == value.isPowerOf2)
+                
+                try value.withUnsafeBinaryIntegerElements {
+                    try #require(expectation == ($0.isPowerOf2))
+                    try #require(expectation == ($0.appendix.isZero && $0.body.isPowerOf2))
+                }
+                
+                try value.withUnsafeBinaryIntegerElements(as: U8.self) {
+                    try #require(expectation == ($0.isPowerOf2))
+                    try #require(expectation == ($0.appendix.isZero && $0.body.isPowerOf2))
+                }
+                
+                try value.withUnsafeMutableBinaryIntegerElements {
+                    try #require(expectation == ($0.isPowerOf2))
+                    try #require(expectation == ($0.appendix.isZero && $0.body.isPowerOf2))
+                }
+                
+                try value.withUnsafeMutableBinaryIntegerElements(as: U8.self) {
+                    try #require(expectation == ($0.isPowerOf2))
+                    try #require(expectation == ($0.appendix.isZero && $0.body.isPowerOf2))
+                }
+            }
+        }
+    }
+    
     //=------------------------------------------------------------------------=
     // MARK: Tests
     //=------------------------------------------------------------------------=


### PR DESCRIPTION
This patch resolves the following:

- #109

It adds `T/isPowerOf2` getters to:

- `BinaryInteger`
- `DataInt<Element>`
- `DataInt<Element>.Body`
- `MutableDataInt<Element>`
- `MutableDataInt<Element>.Body`

Note that `Count/isPowerOf2` was added in an earlier patch.
