### PR TITLE
Faster binary integer descriptions

### DIFF
--- a/Sources/CoreKit/Models/TextInt+Metadata.swift
+++ b/Sources/CoreKit/Models/TextInt+Metadata.swift
@@ -1,0 +1,73 @@
+//=----------------------------------------------------------------------------=
+// This source file is part of the Ultimathnum open source project.
+//
+// Copyright (c)  2023 Oscar Byström Ericsson
+// Licensed under Apache License, Version 2.0
+//
+// See http://www.apache.org/licenses/LICENSE-2.0 for license information.
+//=----------------------------------------------------------------------------=
+
+//*============================================================================*
+// MARK: * Text Int x Metadata
+//*============================================================================*
+
+extension TextInt {
+    
+    //=------------------------------------------------------------------------=
+    // MARK: Metadata
+    //=------------------------------------------------------------------------=
+    
+    /// Magic constants for capacity estimations.
+    ///
+    ///     000000: 32 // multiplier
+    ///     000001: 05 // multiplier shift
+    ///     2...32: floor(32 * log2(radix))
+    ///
+    /// - Note: The `multiplier` adds `5` bits of precision.
+    ///
+    /// - Note: Using `floor` gives pessimistic estimations.
+    ///
+    /// - Note: `37` bytes is a good price for good results.
+    ///
+    /// - Note: Good precision lets us fit more (small) numbers on the stack.
+    ///
+    /// ### Capacity
+    ///
+    /// ```swift
+    /// ceil(32 * length / magicLog2x32[radix])
+    /// ```
+    ///
+    /// ### Comments
+    ///
+    /// Google's open source JavaScript engine, V8, does something similar but
+    /// with different numbers. I believe they use `ceil(x)` instead of `floor(x)`
+    /// at the time of writing. In any case, the equivalent run-time computation
+    /// is straightforward (but less performant).
+    ///
+    @usableFromInline package static let magicLog2x32: [U8] = [
+        032, 005, 032, 050, 064, 074, 082, 089,
+        096, 101, 106, 110, 114, 118, 121, 125,
+        128, 130, 133, 135, 138, 140, 142, 144,
+        146, 148, 150, 152, 153, 155, 157, 158,
+        160, 161, 162, 164, 165
+    ]
+    
+    /// Estimates the `capacity` for the given `radix` and `length`.
+    ///
+    /// - Note: It may fail early due to 1-by-1-as-1 arithmetic (performance).
+    ///
+    /// ### Development
+    ///
+    /// - Todo: Consider double-width arithmetic (it is probably unnecessary).
+    ///
+    @inlinable package static func capacity(_ radix: IX, length: Natural<IX>) -> Optional<IX> {
+        Swift.assert(radix >= 02)
+        Swift.assert(radix <= 36)
+
+        if  length.value.isZero { return 1 }
+        let dividend = length.value.times(IX(Self.magicLog2x32[Swift.Int(00000)]))
+        guard let dividend = dividend.optional() else { return nil }
+        let divisor  = Nonzero(unchecked: IX(Self.magicLog2x32[Swift.Int(radix)]))
+        return dividend.division(divisor).unchecked().ceil().unchecked()
+    }
+}

--- a/Tests/UltimathnumTests/TextInt+Metadata.swift
+++ b/Tests/UltimathnumTests/TextInt+Metadata.swift
@@ -1,0 +1,104 @@
+//=----------------------------------------------------------------------------=
+// This source file is part of the Ultimathnum open source project.
+//
+// Copyright (c)  2023 Oscar Byström Ericsson
+// Licensed under Apache License, Version 2.0
+//
+// See http://www.apache.org/licenses/LICENSE-2.0 for license information.
+//=----------------------------------------------------------------------------=
+
+import CoreKit
+import Foundation
+import TestKit
+
+//*============================================================================*
+// MARK: * Text Int x Metadata
+//*============================================================================*
+
+@Suite(.serialized) struct TextIntTestsOnMetadata {
+    
+    //=------------------------------------------------------------------------=
+    // MARK: Tests
+    //=------------------------------------------------------------------------=
+    
+    @Test(
+        "TextInt/metadata: magicLog2x32",
+        Tag.List.tags(.documentation, .important, .unofficial)
+    )   func magicLog2x32() throws {
+        
+        try #require(TextInt.magicLog2x32[0] == 32)
+        try #require(TextInt.magicLog2x32[1] == 05)
+        
+        for radix: Swift.Int in 2 ... 36 {
+            let expectation = Swift.Int(floor(32 * log2(Swift.Double(radix))))
+            try #require(TextInt.magicLog2x32[radix] == U8(IX((expectation))))
+        }
+    }
+    
+    @Test(
+        "TextInt/metadata: magicLog2x32 max length",
+        Tag.List.tags(.documentation, .important, .unofficial),
+        ConditionTrait.enabled(if: IX.size == Count(64)),
+        arguments: IX(2)...IX(36), CollectionOfOne(IX(load: 288230376151711743 as I64))
+    )   func magicLog2x32MaxLength(radix: IX, length: IX) {
+        
+        #expect(TextInt.capacity(radix, length: Natural(length + 0)) != nil)
+        #expect(TextInt.capacity(radix, length: Natural(length + 1)) == nil)
+    }
+    
+    @Test(
+        "TextInt/metadata: magicLog2x32 decimals",
+        Tag.List.tags(.documentation, .important, .unofficial),
+        ConditionTrait.enabled(if: IX.size == Count(64)),
+        arguments: Array<(U64, IX, IX)>.infer([
+            
+        (U64(00000000000000000000), IX( 1), IX( 1)),
+        (U64(1                   ), IX( 1), IX( 1)),
+        (U64(12                  ), IX( 2), IX( 2)),
+        (U64(123                 ), IX( 3), IX( 3)),
+        (U64(1234                ), IX( 4), IX( 4)),
+        (U64(12345               ), IX( 5), IX( 5)),
+        (U64(123456              ), IX( 6), IX( 6)),
+        (U64(1234567             ), IX( 7), IX( 7)),
+        (U64(12345678            ), IX( 8), IX( 8)),
+        (U64(123456789           ), IX( 9), IX( 9)),
+        (U64(1234567890          ), IX(10), IX(10)),
+        (U64(12345678901         ), IX(11), IX(11)),
+        (U64(123456789012        ), IX(12), IX(12)),
+        (U64(1234567890123       ), IX(13), IX(13)),
+        (U64(12345678901234      ), IX(14), IX(14)),
+        (U64(123456789012345     ), IX(15), IX(15)),
+        (U64(1234567890123456    ), IX(16), IX(16)),
+        (U64(12345678901234567   ), IX(17), IX(17)),
+        (U64(123456789012345678  ), IX(18), IX(18)),
+        (U64(1234567890123456789 ), IX(19), IX(19)),
+        (U64(12345678901234567890), IX(20), IX(20)),
+        (U64(9                   ), IX( 1), IX( 2)), // 1
+        (U64(99                  ), IX( 2), IX( 3)), // 1
+        (U64(999                 ), IX( 3), IX( 4)), // 1
+        (U64(9999                ), IX( 4), IX( 5)), // 1
+        (U64(99999               ), IX( 5), IX( 6)), // 1
+        (U64(999999              ), IX( 6), IX( 7)), // 1
+        (U64(9999999             ), IX( 7), IX( 8)), // 1
+        (U64(99999999            ), IX( 8), IX( 9)), // 1
+        (U64(999999999           ), IX( 9), IX(10)), // 1
+        (U64(9999999999          ), IX(10), IX(11)), // 1
+        (U64(99999999999         ), IX(11), IX(12)), // 1
+        (U64(999999999999        ), IX(12), IX(13)), // 1
+        (U64(9999999999999       ), IX(13), IX(14)), // 1
+        (U64(99999999999999      ), IX(14), IX(15)), // 1
+        (U64(999999999999999     ), IX(15), IX(16)), // 1
+        (U64(9999999999999999    ), IX(16), IX(17)), // 1
+        (U64(99999999999999999   ), IX(17), IX(18)), // 1
+        (U64(999999999999999999  ), IX(18), IX(19)), // 1
+        (U64(9999999999999999999 ), IX(19), IX(20)), // 1
+        
+    ])) func magicLog2x32MaxLength(value: U64, count: IX, expectation: IX) {
+        
+        let length = IX(raw: value.nondescending(Bit.zero))
+        let result = TextInt.capacity(10, length: Natural(length))
+        
+        #expect(result == expectation)
+        #expect(IX(value.description.utf8.count) == count)
+    }
+}


### PR DESCRIPTION
This patch reworks the binary integer description algorithm. 

- it is up to `50%` faster for small integers (depending on radix)

The new implementation:

- uses pointers more efficiently
- uses a better capacity estimation
- corrects over-estimates in place
