### PR TITLE
Faster binary integer descriptions (v2)

### DIFF
--- a/Sources/CoreKit/Models/TextInt+Decoding.swift
+++ b/Sources/CoreKit/Models/TextInt+Decoding.swift
@@ -193,3 +193,31 @@ extension TextInt {
         }
     }
 }
+
+//*============================================================================*
+// MARK: * Text Int x Decoding x Numerals
+//*============================================================================*
+
+extension TextInt.Numerals {
+    
+    //=------------------------------------------------------------------------=
+    // MARK: Utilities
+    //=------------------------------------------------------------------------=
+    
+    /// Decodes the given `numerals` and returns the bit pattern that fits.
+    @inlinable package func load(
+        _ numerals: UnsafeBufferPointer<UInt8>, as type: UX.Type = UX.self
+    )   -> Optional<UX> {
+        
+        var value = UX.zero
+        let radix = UX(load: self.radix)
+        
+        for numeral:  UInt8 in numerals {
+            guard let increment = self.decode(U8(numeral)) else { return nil }
+            value &*= radix
+            value &+= UX(load: increment)
+        }
+        
+        return value
+    }
+}

--- a/Sources/CoreKit/Models/TextInt+Encoding.swift
+++ b/Sources/CoreKit/Models/TextInt+Encoding.swift
@@ -149,7 +149,7 @@ extension TextInt {
     
     /// Returns the contents of `info` followed by the contents of `body`.
     ///
-    /// - parameter body: It must must be normalized or contain exactly one element.
+    /// - parameter body: It must be normalized or contain exactly one element.
     /// 
     @usableFromInline package func encode(
         info: consuming UnsafeBufferPointer<UInt8>,

--- a/Sources/CoreKit/Models/TextInt+Encoding.swift
+++ b/Sources/CoreKit/Models/TextInt+Encoding.swift
@@ -69,7 +69,7 @@ extension TextInt {
 }
 
 //=------------------------------------------------------------------------=
-// MARK: Algorithms
+// MARK: + Algorithms
 //=------------------------------------------------------------------------=
 
 extension TextInt {
@@ -109,10 +109,8 @@ extension TextInt {
                 
         if  Integer.size <= UX.size {
             var small = UX(load: body)
-            let count = IX(Bit(!small.isZero))
-            return Swift.withUnsafeMutablePointer(to: &small) {
-                let normalized = MutableDataInt.Body($0, count: count)
-                return self.encode(info: info, normalized: normalized)
+            return small.withUnsafeMutableBinaryIntegerBody {
+                return self.encode(info: info, quasinormalized: $0)
             }
             
         }   else {
@@ -145,17 +143,21 @@ extension TextInt {
                 words.deinitialize()
             }
             
-            return self.encode(info: info, normalized: words.normalized())
+            return self.encode(info: info, quasinormalized: words.normalized())
         }
     }
     
+    /// Returns the contents of `info` followed by the contents of `body`.
+    ///
+    /// - parameter body: It must must be normalized or contain exactly one element.
+    /// 
     @usableFromInline package func encode(
-        info: consuming  UnsafeBufferPointer<UInt8>,
-        normalized body: consuming MutableDataInt<UX>.Body
+        info: consuming UnsafeBufferPointer<UInt8>,
+        quasinormalized body: consuming MutableDataInt<UX>.Body
     )   -> String {
-        
-        Swift.assert(body.isNormal)
-        
+        //=--------------------------------------=
+        Swift.assert(body.isNormal || (body.count == 1))
+        //=--------------------------------------=
         let (length) = Natural.init(unchecked: IX(raw:  body.nondescending(Bit.zero)))
         var capacity = Swift.Int(Self.capacity(IX(load: self.radix), length: length)!)
         
@@ -168,35 +170,22 @@ extension TextInt {
             var pointer: UnsafeMutablePointer<Swift.UInt8> = end
             var segment: UnsafeMutablePointer<Swift.UInt8> = end
             
-            var chunk:  UX = 0
-            let radix = Nonzero(unchecked: UX(load: self.radix as U8))
-            
-            major:  while true {
-                
-                if  self.power.div != 1 {
-                    chunk = (body).divisionSetQuotientGetRemainder(self.power)
-                    body  = (body).normalized()
-                }   else if !body .isEmpty {
-                    chunk = (body)[unchecked: (  )]
-                    body  = (body)[unchecked: 1...]
+            large: while body.count > 1 {
+                var part: UX
+
+                if  self.power.div == 1 {
+                    part = body[unchecked: (  )]
+                    body = body[unchecked: 1...]
                 }   else {
-                    Swift.assert(chunk.isZero)
+                    part = body.divisionSetQuotientGetRemainder(self.power)
+                    body = body.normalized()
                 }
                 
-                minor:  repeat {
-                    
-                    let value: UX
-                    (chunk, value) = chunk.division(radix).components()
-                    let element = Swift.UInt8(self.numerals.encode(U8(load: value)).unchecked())
-                    precondition(pointer > start)
-                    pointer = pointer.predecessor()
-                    pointer.initialize(to: element)
-                    
-                }   while !chunk.isZero
+                self.numerals.backwards(
+                    part, start: start, end: &pointer
+                )
                 
-                if body.isEmpty { break }
-                
-                segment = segment - Swift.Int(self.exponent)
+                segment -= Swift.Int(self.exponent)
                 
                 while pointer >  segment {
                     precondition(pointer > start)
@@ -204,6 +193,10 @@ extension TextInt {
                     pointer.initialize(to: 0x30)
                 }
             }
+            
+            self.numerals.backwards(
+                body.first ?? UX.zero, start: start, end: &pointer
+            )
             
             for element in info.reversed() {
                 precondition(pointer > start)
@@ -226,5 +219,35 @@ extension TextInt {
             
             return count // as Swift.Int as Swift.Int
         }
+    }
+}
+
+//*============================================================================*
+// MARK: * Text Int x Encoding x Numerals
+//*============================================================================*
+
+extension TextInt.Numerals {
+    
+    //=------------------------------------------------------------------------=
+    // MARK: Utilities
+    //=------------------------------------------------------------------------=
+    
+    @inlinable package func backwards(
+        _ magnitude: consuming UX,
+        start: Swift.UnsafeMutablePointer<Swift.UInt8>,
+        end:   inout UnsafeMutablePointer<Swift.UInt8>
+    ) {
+        
+        var remainder: UX
+        let radix = Nonzero(unchecked: UX(load: self.radix as U8))
+        repeat {
+            
+            (magnitude, remainder) = magnitude.division(radix).components()
+            let element = self.encode(U8.init(load: remainder)).unchecked()
+            precondition(start < end)
+            end = end.predecessor()
+            end.initialize(to: Swift.UInt8(element))
+            
+        }   while !magnitude.isZero
     }
 }

--- a/Sources/CoreKit/Models/TextInt+Numerals.swift
+++ b/Sources/CoreKit/Models/TextInt+Numerals.swift
@@ -52,7 +52,7 @@ extension TextInt {
         
         /// Creates a new instance with a radix of `10`.
         @inlinable public init() {
-            self.init(radix: 10)!
+            self = Self(radix: 10).unchecked()
         }
         
         /// Creates a new instance using the given `radix` and `letters`.

--- a/Sources/CoreKit/Models/TextInt+Numerals.swift
+++ b/Sources/CoreKit/Models/TextInt+Numerals.swift
@@ -20,23 +20,23 @@ extension TextInt {
         // MARK: State
         //=--------------------------------------------------------------------=
         
+        /// The radix of its number system.
+        ///
+        /// - Note: It is an integer in `2...36`.
+        ///
+        public let radix: U8
+        
         /// The number of numerals in the range `0..<10`.
         ///
         /// - Note: It equals `min(10, radix)`.
         ///
-        @usableFromInline let i00x10: U8
+        @usableFromInline let i0010: U8
         
         /// The number of numerals in the range `10..<36`.
         ///
         /// - Note: It equals `max(0, radix - 10)`.
         ///
-        @usableFromInline let i10x36: U8
-        
-        /// The start for numerals in the range `0..<10`
-        ///
-        /// - Note: The `decimal` start is `48`.
-        ///
-        @usableFromInline let o00x10: U8
+        @usableFromInline let i1036: U8
         
         /// The start for numerals in the range `10..<36`
         ///
@@ -44,7 +44,7 @@ extension TextInt {
         ///
         /// - Note: The lowercase start is `97`.
         ///
-        @usableFromInline var o10x36: U8
+        @usableFromInline var o1036: U8
         
         //=--------------------------------------------------------------------=
         // MARK: Initializers
@@ -68,19 +68,21 @@ extension TextInt {
         ///
         /// - Requires: `0 ≤ radix ≤ 36`
         ///
-        @inlinable public init?(radix: UX,letters: Letters = .lowercase) {
-            if  radix <= 10 {
-                self.i00x10 = U8(load: radix)
-                self.i10x36 = U8.zero
+        @inlinable public init?(radix: UX, letters: Letters = .lowercase) {
+            self.radix = U8(load: radix)
+            self.o1036 = (letters.start)
+            
+            if  radix <=  10 {
+                self.i0010 = self.radix
+                self.i1036 = 0000000000
+                
             }   else if radix <= 36 {
-                self.i00x10 = 0000010
-                self.i10x36 = U8(load: radix).minus(10).unchecked()
+                self.i0010 = 0000000010
+                self.i1036 = self.radix.minus(10).unchecked()
+                
             }   else {
                 return nil
             }
-            
-            self.o00x10 = 48
-            self.o10x36 = letters.start
         }
         
         //=--------------------------------------------------------------------=
@@ -99,7 +101,7 @@ extension TextInt {
         
         /// Returns an similar instance that encodes the given `letters`.
         @inlinable public consuming func letters(_ letters: Letters) -> Self {
-            self.o10x36 = letters.start
+            self.o1036 = letters.start
             return self
         }
         
@@ -107,20 +109,12 @@ extension TextInt {
         // MARK: Utilities
         //=--------------------------------------------------------------------=
         
-        /// The radix of its number system.
-        ///
-        /// - Returns: A integer in `2...36`.
-        ///
-        @inlinable public var radix: U8 {
-            self.i00x10 &+ self.i10x36
-        }
-        
         /// The kind of letters produced by its encoding methods.
         @inlinable public var letters: Letters {
-            if  self.o10x36 == Letters.uppercase.start {
+            if  self.o1036 == Letters.uppercase.start {
                 return Letters.uppercase
             }   else {
-                Swift.assert(self.o10x36 == Letters.lowercase.start)
+                Swift.assert(self.o1036 == Letters.lowercase.start)
                 return Letters.lowercase
             }
         }
@@ -134,13 +128,13 @@ extension TextInt {
         @inlinable public func decode(_ data: U8) -> Optional<U8> {
             var next = data &- 48
             
-            if  next < self.i00x10 {
+            if  next < self.i0010 {
                 return next
             }
             
             next = (data | 32) &- 97
             
-            if  next < self.i10x36 {
+            if  next < self.i1036 {
                 return next &+ 10
             }
             
@@ -158,38 +152,17 @@ extension TextInt {
         /// - Note: This conversion is case-sensitive.
         ///
         @inlinable public func encode(_ data: U8) -> Optional<U8> {
-            if  data < self.i00x10 {
-                return data &+ self.o00x10
+            if  data < self.i0010 {
+                return data &+ 48
             }
             
             let next = data &- 10
             
-            if  next < self.i10x36 {
-                return next &+ self.o10x36
+            if  next < self.i1036 {
+                return next &+ self.o1036
             }
             
             return nil
-        }
-        
-        //=--------------------------------------------------------------------=
-        // MARK: Utilities
-        //=--------------------------------------------------------------------=
-        
-        /// Decodes the given `numerals` and returns the bit pattern that fits.
-        @inlinable package func load(
-            _ numerals: UnsafeBufferPointer<UInt8>, as type: UX.Type = UX.self
-        )   -> Optional<UX> {
-            
-            var value = UX.zero
-            let radix = UX(load: self.radix)
-            
-            for numeral:  UInt8 in numerals {
-                guard let increment = self.decode(U8(numeral)) else { return nil }
-                value &*= radix
-                value &+= UX(load: increment)
-            }
-            
-            return value
         }
     }
 }


### PR DESCRIPTION
This patch follows (#146), taking the 64-bit loop benchmarks to:

- `21` ms from `30` ms using radix `10`
- `17` ms from `20` ms using radix `16`

The new implementation focuses on small integer inputs such that:

- the numerals model now store its radix
- magnitudes that fit in UX don't need to perform power divisions
- the binary integer body does not need to be entirely normalized
