### PR TITLE
Unavailable I128 and U128 models

### DIFF
--- a/Sources/CoreIop/BinaryInteger.swift
+++ b/Sources/CoreIop/BinaryInteger.swift
@@ -13,14 +13,22 @@ import CoreKit
 // MARK: * Binary Integer
 //*============================================================================*
 
-extension IX:  CompactIntegerInteroperable { }
-extension I8:  CompactIntegerInteroperable { }
-extension I16: CompactIntegerInteroperable { }
-extension I32: CompactIntegerInteroperable { }
-extension I64: CompactIntegerInteroperable { }
+extension IX:   CompactIntegerInteroperable { }
+extension I8:   CompactIntegerInteroperable { }
+extension I16:  CompactIntegerInteroperable { }
+extension I32:  CompactIntegerInteroperable { }
+extension I64:  CompactIntegerInteroperable { }
 
-extension UX:  NaturalIntegerInteroperable { }
-extension U8:  NaturalIntegerInteroperable { }
-extension U16: NaturalIntegerInteroperable { }
-extension U32: NaturalIntegerInteroperable { }
-extension U64: NaturalIntegerInteroperable { }
+@available(*, unavailable)
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
+extension I128: CompactIntegerInteroperable { }
+
+extension UX:   NaturalIntegerInteroperable { }
+extension U8:   NaturalIntegerInteroperable { }
+extension U16:  NaturalIntegerInteroperable { }
+extension U32:  NaturalIntegerInteroperable { }
+extension U64:  NaturalIntegerInteroperable { }
+
+@available(*, unavailable)
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
+extension U128: NaturalIntegerInteroperable { }

--- a/Sources/CoreKit/Models/CoreInt.swift
+++ b/Sources/CoreKit/Models/CoreInt.swift
@@ -235,6 +235,52 @@
 }
 
 //*============================================================================*
+// MARK: * Core Int x I128
+//*============================================================================*
+
+/// A 128-bit signed binary integer.
+@available(*, unavailable)
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
+@frozen public struct I128: CoreInteger, SignedInteger, CoreIntegerWhereIsNotByte, CoreIntegerWhereIsNotToken {
+    
+    public typealias Stdlib = Swift.Int128
+    
+    public typealias BitPattern = Stdlib.BitPattern
+    
+    public typealias Element = Self
+        
+    public typealias Signitude = Self
+    
+    public typealias Magnitude = U128
+    
+    //=------------------------------------------------------------------------=
+    // MARK: State
+    //=------------------------------------------------------------------------=
+    
+    @usableFromInline var base: Stdlib
+    
+    //=------------------------------------------------------------------------=
+    // MARK: Initializers
+    //=------------------------------------------------------------------------=
+    
+    @inlinable public init(_ source: Stdlib) {
+        self.base = source
+    }
+    
+    @inlinable public init(raw source: BitPattern) {
+        self.base = Stdlib(bitPattern: source)
+    }
+    
+    @inlinable public init(integerLiteral source: Stdlib) {
+        self.base = source
+    }
+    
+    @inlinable public consuming func stdlib() -> Stdlib {
+        self.base
+    }
+}
+
+//*============================================================================*
 // MARK: * Core Int x UX
 //*============================================================================*
 
@@ -424,6 +470,52 @@
     public typealias Element = Self
             
     public typealias Signitude = I64
+    
+    public typealias Magnitude = Self
+    
+    //=------------------------------------------------------------------------=
+    // MARK: State
+    //=------------------------------------------------------------------------=
+    
+    @usableFromInline var base: Stdlib
+    
+    //=------------------------------------------------------------------------=
+    // MARK: Initializers
+    //=------------------------------------------------------------------------=
+    
+    @inlinable public init(_ source: Stdlib) {
+        self.base = source
+    }
+    
+    @inlinable public init(raw source: BitPattern) {
+        self.base = source
+    }
+    
+    @inlinable public init(integerLiteral source: Stdlib) {
+        self.base = source
+    }
+    
+    @inlinable public consuming func stdlib() -> Stdlib {
+        self.base
+    }
+}
+
+//*============================================================================*
+// MARK: * Core Int x U128
+//*============================================================================*
+
+/// A 128-bit unsigned binary integer.
+@available(*, unavailable)
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
+@frozen public struct U128: CoreInteger, UnsignedInteger, CoreIntegerWhereIsNotByte, CoreIntegerWhereIsNotToken {
+    
+    public typealias Stdlib = Swift.UInt128
+    
+    public typealias BitPattern = Stdlib.BitPattern
+    
+    public typealias Element = Self
+            
+    public typealias Signitude = I128
     
     public typealias Magnitude = Self
     

--- a/Sources/CoreKit/Stdlib/Swift+Int.swift
+++ b/Sources/CoreKit/Stdlib/Swift+Int.swift
@@ -101,3 +101,24 @@ extension Int64: BitCastable {
         Magnitude(bitPattern: self)
     }
 }
+
+//*============================================================================*
+// MARK: * Swift x Int128
+//*============================================================================*
+
+@available(*, unavailable)
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
+extension Int128: BitCastable {
+    
+    //=------------------------------------------------------------------------=
+    // MARK: Initializers
+    //=------------------------------------------------------------------------=
+    
+    @inlinable public init(raw source: consuming Magnitude) {
+        self.init(bitPattern: source)
+    }
+    
+    @inlinable public consuming func load(as type: Magnitude.Type) -> Magnitude {
+        Magnitude(bitPattern: self)
+    }
+}

--- a/Sources/CoreKit/Stdlib/Swift+UInt.swift
+++ b/Sources/CoreKit/Stdlib/Swift+UInt.swift
@@ -36,3 +36,11 @@ extension UInt32: BitCastable { public typealias BitPattern = Magnitude }
 //*============================================================================*
 
 extension UInt64: BitCastable { public typealias BitPattern = Magnitude }
+
+//*============================================================================*
+// MARK: * Swift x UInt128
+//*============================================================================*
+
+@available(*, unavailable)
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
+extension UInt128: BitCastable { public typealias BitPattern = Magnitude }

--- a/Tests/UltimathiopTests/Utilities/Globals.swift
+++ b/Tests/UltimathiopTests/Utilities/Globals.swift
@@ -42,14 +42,42 @@ let typesAsLenientIntegerInteroperable: [any LenientIntegerInteroperable.Type] =
     InfiniInt<IX>.self,
 ]
 
-let typesAsCompactIntegerInteroperable: [any CompactIntegerInteroperable.Type] = [
-    IX.self,  I8 .self, I16.self, I32.self, I64 .self,
-    DoubleInt<I8>.self, DoubleInt<DoubleInt<I8>>.self,
-    DoubleInt<IX>.self, DoubleInt<DoubleInt<IX>>.self,
-]
+let typesAsCompactIntegerInteroperable: [any CompactIntegerInteroperable.Type] = reduce([]) {
+    $0.append(IX .self)
+    $0.append(I8 .self)
+    $0.append(I16.self)
+    $0.append(I32.self)
+    $0.append(I64.self)
+    
+    #if false
+    if  #available(iOS 18.0, macOS 15.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *) {
+        $0.append(I128.self)
+    }
+    #endif
+    
+    $0.append(DoubleInt<I8>.self)
+    $0.append(DoubleInt<IX>.self)
+    
+    $0.append(DoubleInt<DoubleInt<I8>>.self)
+    $0.append(DoubleInt<DoubleInt<IX>>.self)
+}
 
-let typesAsNaturalIntegerInteroperable: [any NaturalIntegerInteroperable.Type] = [
-    UX.self,  U8 .self, U16.self, U32.self, U64 .self,
-    DoubleInt<U8>.self, DoubleInt<DoubleInt<U8>>.self,
-    DoubleInt<UX>.self, DoubleInt<DoubleInt<UX>>.self,
-]
+let typesAsNaturalIntegerInteroperable: [any NaturalIntegerInteroperable.Type] = reduce([]) {
+    $0.append(UX .self)
+    $0.append(U8 .self)
+    $0.append(U16.self)
+    $0.append(U32.self)
+    $0.append(U64.self)
+    
+    #if false
+    if #available(iOS 18.0, macOS 15.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *) {
+        $0.append(CoreKit.U128.self)
+    }
+    #endif
+    
+    $0.append(DoubleInt<U8>.self)
+    $0.append(DoubleInt<UX>.self)
+    
+    $0.append(DoubleInt<DoubleInt<U8>>.self)
+    $0.append(DoubleInt<DoubleInt<UX>>.self)
+}

--- a/Tests/UltimathnumTests/Utilities/Globals.swift
+++ b/Tests/UltimathnumTests/Utilities/Globals.swift
@@ -102,14 +102,42 @@ let typesAsSystemsInteger: [any SystemsInteger.Type] = {
     typesAsSystemsIntegerAsUnsigned
 }()
 
-let typesAsSystemsIntegerAsSigned: [any SystemsIntegerAsSigned.Type] = [
-    IX.self,  I8 .self, I16.self, I32.self, I64 .self,
-    DoubleInt<I8>.self, DoubleInt<DoubleInt<I8>>.self,
-    DoubleInt<IX>.self, DoubleInt<DoubleInt<IX>>.self,
-]
+let typesAsSystemsIntegerAsSigned: [any SystemsIntegerAsSigned.Type] = reduce([]) {
+    $0.append(IX .self)
+    $0.append(I8 .self)
+    $0.append(I16.self)
+    $0.append(I32.self)
+    $0.append(I64.self)
+    
+    #if false
+    if  #available(iOS 18.0, macOS 15.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *) {
+        $0.append(I128.self)
+    }
+    #endif
+    
+    $0.append(DoubleInt<I8>.self)
+    $0.append(DoubleInt<IX>.self)
+    
+    $0.append(DoubleInt<DoubleInt<I8>>.self)
+    $0.append(DoubleInt<DoubleInt<IX>>.self)
+}
 
-let typesAsSystemsIntegerAsUnsigned: [any SystemsIntegerAsUnsigned.Type] = [
-    UX.self,  U8 .self, U16.self, U32.self, U64 .self,
-    DoubleInt<U8>.self, DoubleInt<DoubleInt<U8>>.self,
-    DoubleInt<UX>.self, DoubleInt<DoubleInt<UX>>.self,
-]
+let typesAsSystemsIntegerAsUnsigned: [any SystemsIntegerAsUnsigned.Type] = reduce([]) {
+    $0.append(UX .self)
+    $0.append(U8 .self)
+    $0.append(U16.self)
+    $0.append(U32.self)
+    $0.append(U64.self)
+    
+    #if false
+    if #available(iOS 18.0, macOS 15.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *) {
+        $0.append(CoreKit.U128.self)
+    }
+    #endif
+    
+    $0.append(DoubleInt<U8>.self)
+    $0.append(DoubleInt<UX>.self)
+    
+    $0.append(DoubleInt<DoubleInt<U8>>.self)
+    $0.append(DoubleInt<DoubleInt<UX>>.self)
+}


### PR DESCRIPTION
This patch adds **unavailable** `I128` and `U128` models (#143).

The underlying `Swift.Int128` and `Swift.UInt128` models fail some tests (crash). I have submitted some fixes that got merged into the `Swift 6.1` branch. I'll try again later and make the `I128` and `U128` available when all tests pass successfully.